### PR TITLE
feat(qml): Add QLSTM implementation based on arXiv:2009.01783

### DIFF
--- a/examples/qlstm_demo.rs
+++ b/examples/qlstm_demo.rs
@@ -1,0 +1,401 @@
+//! Quantum Long Short-Term Memory (QLSTM) Demonstration
+//!
+//! This example demonstrates the QLSTM implementation based on:
+//! - "Quantum Long Short-Term Memory" (arXiv:2009.01783) by Chen et al.
+//! - PennyLane's Learning to Learn with Quantum Neural Networks
+//!
+//! The QLSTM is a hybrid quantum-classical model where the LSTM gates
+//! are implemented using Variational Quantum Circuits (VQCs).
+//!
+//! # Tasks Demonstrated:
+//! 1. Basic QLSTM forward pass
+//! 2. Sequence prediction (sine wave)
+//! 3. Simple pattern learning
+//! 4. Comparison of different VQC types
+//! 5. QLSTM visualization and diagram generation
+
+use logosq::qml::{
+    mse_loss, QLSTMConfig, QLSTMTrainer, VQCType, VariationalQuantumCircuit, QLSTM,
+};
+use logosq::vis::{qlstm_text, vqc_text, save_qlstm_svg, save_vqc_svg, Visualizable};
+use rand::Rng;
+use std::f64::consts::PI;
+
+/// Generate a sine wave sequence
+fn generate_sine_sequence(num_samples: usize, frequency: f64) -> Vec<Vec<f64>> {
+    (0..num_samples)
+        .map(|i| {
+            let t = (i as f64) / (num_samples as f64) * 2.0 * PI * frequency;
+            vec![t.sin()]
+        })
+        .collect()
+}
+
+
+/// Demo 1: Basic QLSTM Forward Pass
+fn demo_basic_forward() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 1: Basic QLSTM Forward Pass");
+    println!("{}", "=".repeat(70));
+
+    // Create QLSTM configuration
+    let config = QLSTMConfig::new(1, 2) // input_size=1, hidden_size=2
+        .with_num_layers(1)
+        .with_num_qubits(3);
+
+    println!("QLSTM Configuration:");
+    println!("  Input size: {}", config.input_size);
+    println!("  Hidden size: {}", config.hidden_size);
+    println!("  Number of qubits: {}", config.num_qubits);
+    println!("  Number of VQC layers: {}", config.num_layers);
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+    println!("  Total parameters: {}", num_params);
+
+    // Initialize random parameters
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-PI..PI)).collect();
+
+    // Create a simple sequence
+    let sequence = vec![vec![0.1], vec![0.2], vec![0.3], vec![0.4], vec![0.5]];
+
+    println!("\nInput sequence: {:?}", sequence);
+
+    // Forward pass
+    let output = qlstm.forward(&sequence, &params, None, None);
+
+    println!("Output (final hidden state): {:?}", output[0]);
+    println!(
+        "Output values are in range [-1, 1] (transformed by sigmoid/tanh)"
+    );
+}
+
+/// Demo 2: QLSTM with Return Sequences
+fn demo_return_sequences() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 2: QLSTM with Return Sequences");
+    println!("{}", "=".repeat(70));
+
+    let config = QLSTMConfig::new(1, 2).with_num_layers(1).with_num_qubits(3);
+
+    let qlstm = QLSTM::new(config).with_return_sequences(true);
+
+    let num_params = qlstm.num_parameters();
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-PI..PI)).collect();
+
+    let sequence = vec![vec![0.1], vec![0.2], vec![0.3], vec![0.4]];
+
+    println!("Input sequence length: {}", sequence.len());
+
+    let outputs = qlstm.forward(&sequence, &params, None, None);
+
+    println!("Number of outputs: {}", outputs.len());
+    println!("\nOutputs at each time step:");
+    for (t, output) in outputs.iter().enumerate() {
+        println!("  t={}: {:?}", t, output);
+    }
+}
+
+/// Demo 3: VQC Types Comparison
+fn demo_vqc_types() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 3: VQC Types Comparison");
+    println!("{}", "=".repeat(70));
+
+    let vqc_types = vec![
+        ("Simple", VQCType::Simple),
+        ("BasicEntangling", VQCType::BasicEntangling),
+        ("StronglyEntangling", VQCType::StronglyEntangling),
+    ];
+
+    let input = vec![0.5, 0.3, 0.1];
+
+    for (name, vqc_type) in vqc_types {
+        let vqc = VariationalQuantumCircuit {
+            num_qubits: 3,
+            num_layers: 2,
+            vqc_type: vqc_type.clone(),
+            include_input_encoding: true,
+        };
+
+        let num_params = vqc.num_variational_params();
+        let mut rng = rand::thread_rng();
+        let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-PI..PI)).collect();
+
+        let output = vqc.forward(&input, &params);
+
+        println!("\n{} VQC:", name);
+        println!("  Parameters: {}", num_params);
+        println!("  Output: {:?}", output);
+    }
+}
+
+/// Demo 4: Simple Training Example
+fn demo_training() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 4: Simple QLSTM Training");
+    println!("{}", "=".repeat(70));
+
+    // Create a small QLSTM
+    let config = QLSTMConfig::new(1, 2).with_num_layers(1).with_num_qubits(3);
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    println!("Training QLSTM to predict a simple pattern...");
+    println!("Number of parameters: {}", num_params);
+
+    // Initialize parameters
+    let mut rng = rand::thread_rng();
+    let initial_params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.5..0.5)).collect();
+
+    // Training data: simple ascending pattern
+    let sequence = vec![vec![0.1], vec![0.2], vec![0.3]];
+    let target = vec![0.4, 0.5]; // Expected output pattern
+
+    // Create trainer
+    let trainer = QLSTMTrainer {
+        learning_rate: 0.05,
+        max_iterations: 50,
+        tolerance: 1e-4,
+        verbose: true,
+    };
+
+    // Train
+    let (optimized_params, final_loss) = trainer.train(&qlstm, &sequence, &target, &initial_params);
+
+    println!("\nTraining completed!");
+    println!("Final loss: {:.6}", final_loss);
+
+    // Test the trained model
+    let output = qlstm.forward(&sequence, &optimized_params, None, None);
+    println!("Target: {:?}", target);
+    println!("Predicted: {:?}", output[0]);
+}
+
+/// Demo 5: Sine Wave Prediction
+fn demo_sine_prediction() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 5: Sine Wave Sequence Prediction");
+    println!("{}", "=".repeat(70));
+
+    let config = QLSTMConfig::new(1, 2).with_num_layers(1).with_num_qubits(4);
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    // Generate sine wave data
+    let full_sequence = generate_sine_sequence(10, 1.0);
+    let input_seq: Vec<Vec<f64>> = full_sequence[..5].to_vec();
+    let target: Vec<f64> = full_sequence[5].clone();
+
+    println!("Input sequence (first 5 points of sine wave):");
+    for (i, x) in input_seq.iter().enumerate() {
+        println!("  t={}: {:.4}", i, x[0]);
+    }
+    println!("Target (6th point): {:.4}", target[0]);
+
+    // Initialize and predict
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-PI..PI)).collect();
+
+    let output = qlstm.forward(&input_seq, &params, None, None);
+
+    println!("\nPrediction (untrained): {:?}", output[0]);
+    println!(
+        "Note: The untrained model gives random predictions."
+    );
+    println!("Training would optimize parameters to minimize prediction error.");
+}
+
+/// Demo 6: Computing Gradients
+fn demo_gradients() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 6: Computing Gradients via Parameter-Shift Rule");
+    println!("{}", "=".repeat(70));
+
+    let config = QLSTMConfig::new(1, 2).with_num_layers(1).with_num_qubits(3);
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    println!("Computing gradients for {} parameters...", num_params);
+
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.5..0.5)).collect();
+
+    let sequence = vec![vec![0.5], vec![0.3]];
+    let target = vec![0.7, 0.2];
+
+    // Compute initial loss
+    let output = qlstm.forward(&sequence, &params, None, None);
+    let loss = mse_loss(&output[0], &target);
+    println!("Initial loss: {:.6}", loss);
+
+    // Compute gradients
+    let gradients = qlstm.compute_gradient(&sequence, &target, &params, mse_loss);
+
+    println!("\nGradients (first 8 parameters):");
+    for (i, g) in gradients.iter().take(8).enumerate() {
+        println!("  ∂L/∂θ[{}] = {:.6}", i, g);
+    }
+
+    // Verify gradient by numerical approximation
+    let eps = 1e-4;
+    println!("\nNumerical gradient verification (first 3 parameters):");
+    for i in 0..3.min(num_params) {
+        let mut params_plus = params.clone();
+        params_plus[i] += eps;
+        let out_plus = qlstm.forward(&sequence, &params_plus, None, None);
+        let loss_plus = mse_loss(&out_plus[0], &target);
+
+        let mut params_minus = params.clone();
+        params_minus[i] -= eps;
+        let out_minus = qlstm.forward(&sequence, &params_minus, None, None);
+        let loss_minus = mse_loss(&out_minus[0], &target);
+
+        let numerical_grad = (loss_plus - loss_minus) / (2.0 * eps);
+        println!(
+            "  θ[{}]: analytical={:.6}, numerical={:.6}, diff={:.6}",
+            i,
+            gradients[i],
+            numerical_grad,
+            (gradients[i] - numerical_grad).abs()
+        );
+    }
+}
+
+/// Demo 7: QLSTM Architecture Overview
+fn demo_architecture() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 7: QLSTM Architecture Overview");
+    println!("{}", "=".repeat(70));
+
+    println!("\nClassical LSTM Cell:");
+    println!("  f_t = σ(W_f · [h_{{t-1}}, x_t] + b_f)  [Forget Gate]");
+    println!("  i_t = σ(W_i · [h_{{t-1}}, x_t] + b_i)  [Input Gate]");
+    println!("  c̃_t = tanh(W_c · [h_{{t-1}}, x_t] + b_c)  [Cell Gate]");
+    println!("  o_t = σ(W_o · [h_{{t-1}}, x_t] + b_o)  [Output Gate]");
+    println!("  c_t = f_t ⊙ c_{{t-1}} + i_t ⊙ c̃_t");
+    println!("  h_t = o_t ⊙ tanh(c_t)");
+
+    println!("\nQLSTM Cell (Quantum Version):");
+    println!("  f_t = σ(VQC_f(h_{{t-1}}, x_t; θ_f))  [Quantum Forget Gate]");
+    println!("  i_t = σ(VQC_i(h_{{t-1}}, x_t; θ_i))  [Quantum Input Gate]");
+    println!("  c̃_t = tanh(VQC_c(h_{{t-1}}, x_t; θ_c))  [Quantum Cell Gate]");
+    println!("  o_t = σ(VQC_o(h_{{t-1}}, x_t; θ_o))  [Quantum Output Gate]");
+    println!("  (Cell state and hidden state updates remain classical)");
+
+    println!("\nVQC Structure:");
+    println!("  1. Input encoding: RY(π·x_i) for each input on qubit i");
+    println!("  2. Variational layers:");
+    println!("     - Rotation gates: RY(θ), RZ(θ)");
+    println!("     - Entangling gates: CNOT ladder");
+    println!("  3. Measurement: Z expectation on each qubit");
+
+    println!("\nReferences:");
+    println!("  [1] Chen et al., 'Quantum Long Short-Term Memory'");
+    println!("      arXiv:2009.01783 (2020)");
+    println!("  [2] PennyLane: Learning to Learn with Quantum Neural Networks");
+    println!("      https://pennylane.ai/qml/demos/learning2learn");
+}
+
+/// Demo 8: QLSTM Visualization
+fn demo_visualization() {
+    println!("\n{}", "=".repeat(70));
+    println!("Demo 8: QLSTM Visualization & Diagram Generation");
+    println!("{}", "=".repeat(70));
+
+    // Create QLSTM configuration
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(2)
+        .with_num_qubits(4)
+        .with_vqc_type(VQCType::BasicEntangling);
+
+    // Print text diagram
+    println!("\n--- QLSTM Cell Text Diagram ---\n");
+    println!("{}", qlstm_text(&config));
+
+    // Create and visualize VQC
+    let vqc = VariationalQuantumCircuit {
+        num_qubits: 4,
+        num_layers: 2,
+        vqc_type: VQCType::BasicEntangling,
+        include_input_encoding: true,
+    };
+
+    println!("\n--- VQC Text Diagram ---\n");
+    println!("{}", vqc_text(&vqc));
+
+    // Save SVG diagrams
+    println!("\nGenerating SVG diagrams...");
+    
+    match save_qlstm_svg(&config, "qlstm_cell.svg") {
+        Ok(_) => println!("  ✓ Saved QLSTM cell diagram to: qlstm_cell.svg"),
+        Err(e) => println!("  ✗ Failed to save QLSTM diagram: {}", e),
+    }
+
+    match save_vqc_svg(&vqc, "qlstm_vqc.svg") {
+        Ok(_) => println!("  ✓ Saved VQC diagram to: qlstm_vqc.svg"),
+        Err(e) => println!("  ✗ Failed to save VQC diagram: {}", e),
+    }
+
+    // Also save using the Visualizable trait
+    let qlstm = QLSTM::new(config.clone());
+    match qlstm.save_visualization("qlstm_full.svg") {
+        Ok(_) => println!("  ✓ Saved full QLSTM diagram to: qlstm_full.svg"),
+        Err(e) => println!("  ✗ Failed to save full QLSTM diagram: {}", e),
+    }
+
+    // Save different VQC types for comparison
+    println!("\nGenerating VQC type comparison diagrams...");
+    
+    let vqc_types = [
+        ("Simple", VQCType::Simple),
+        ("BasicEntangling", VQCType::BasicEntangling),
+        ("StronglyEntangling", VQCType::StronglyEntangling),
+    ];
+
+    for (name, vqc_type) in &vqc_types {
+        let vqc = VariationalQuantumCircuit {
+            num_qubits: 3,
+            num_layers: 2,
+            vqc_type: vqc_type.clone(),
+            include_input_encoding: true,
+        };
+        
+        let filename = format!("vqc_{}.svg", name.to_lowercase());
+        match save_vqc_svg(&vqc, &filename) {
+            Ok(_) => println!("  ✓ Saved {} VQC diagram to: {}", name, filename),
+            Err(e) => println!("  ✗ Failed to save {} VQC diagram: {}", name, e),
+        }
+    }
+
+    println!("\nVisualization complete!");
+    println!("Open the SVG files in a web browser to view the diagrams.");
+}
+
+fn main() {
+    println!("{}", "=".repeat(70));
+    println!("Quantum Long Short-Term Memory (QLSTM) Demonstration");
+    println!("{}", "=".repeat(70));
+    println!("\nThis example demonstrates the QLSTM implementation based on:");
+    println!("  - arXiv:2009.01783 'Quantum Long Short-Term Memory'");
+    println!("  - PennyLane's Learning to Learn tutorial");
+
+    // Run demos
+    demo_architecture();
+    demo_basic_forward();
+    demo_return_sequences();
+    demo_vqc_types();
+    demo_gradients();
+    demo_sine_prediction();
+    demo_training();
+    demo_visualization();
+
+    println!("\n{}", "=".repeat(70));
+    println!("QLSTM Demonstration Complete!");
+    println!("{}", "=".repeat(70));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod gates;
 pub mod noise;
 pub mod optimization;
 pub mod prelude;
+pub mod qml;
 pub mod simulators;
 pub mod states;
 pub mod utils;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -161,7 +161,7 @@ pub use crate::qml::{
     // Data encoding
     data_encoding::{AmplitudeEncoding, AngleEncoding, DataEncoder, IQPEncoding},
     // QLSTM
-    qlstm::{mse_loss, cross_entropy_loss, QLSTMCell, QLSTMConfig, QLSTMOutput, QLSTMTrainer, QLSTM},
+    qlstm::{mse_loss, cross_entropy_loss, cross_entropy_loss_probabilities, QLSTMCell, QLSTMConfig, QLSTMOutput, QLSTMTrainer, QLSTM},
     // VQC
     vqc::{DressedVQC, VQCBuilder, VQCType, VariationalQuantumCircuit},
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -154,6 +154,19 @@ pub use crate::noise::{
 };
 
 // ============================================================================
+// QUANTUM MACHINE LEARNING
+// ============================================================================
+
+pub use crate::qml::{
+    // Data encoding
+    data_encoding::{AmplitudeEncoding, AngleEncoding, DataEncoder, IQPEncoding},
+    // QLSTM
+    qlstm::{mse_loss, cross_entropy_loss, QLSTMCell, QLSTMConfig, QLSTMOutput, QLSTMTrainer, QLSTM},
+    // VQC
+    vqc::{DressedVQC, VQCBuilder, VQCType, VariationalQuantumCircuit},
+};
+
+// ============================================================================
 // COMMON CONSTANTS
 // ============================================================================
 

--- a/src/qml/data_encoding.rs
+++ b/src/qml/data_encoding.rs
@@ -1,0 +1,284 @@
+//! Data encoding strategies for quantum machine learning
+//!
+//! This module provides various methods to encode classical data into quantum states,
+//! which is essential for quantum machine learning algorithms.
+
+use crate::circuits::Circuit;
+use std::f64::consts::PI;
+
+/// Trait for data encoding into quantum circuits
+pub trait DataEncoder {
+    /// Encode classical data into a quantum circuit
+    ///
+    /// # Arguments
+    /// * `circuit` - The quantum circuit to add encoding gates to
+    /// * `data` - Classical data to encode (values typically in range [0, 1] or [-1, 1])
+    fn encode(&self, circuit: &mut Circuit, data: &[f64]);
+
+    /// Get the number of qubits required for encoding the given data size
+    fn required_qubits(&self, data_size: usize) -> usize;
+}
+
+/// Angle encoding: encodes data as rotation angles
+///
+/// Each data point is encoded as a rotation angle on a separate qubit.
+/// This is the most common encoding for variational quantum circuits.
+///
+/// For data x ∈ [-1, 1]:
+///   - Apply RY(π * x) or RX(π * x) to each qubit
+#[derive(Clone, Debug)]
+pub struct AngleEncoding {
+    /// Rotation axis: 'X', 'Y', or 'Z'
+    pub axis: char,
+    /// Scaling factor for the angles (default: π)
+    pub scale: f64,
+    /// Number of repetitions (data re-uploading)
+    pub repetitions: usize,
+}
+
+impl Default for AngleEncoding {
+    fn default() -> Self {
+        Self {
+            axis: 'Y',
+            scale: PI,
+            repetitions: 1,
+        }
+    }
+}
+
+impl AngleEncoding {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_axis(mut self, axis: char) -> Self {
+        assert!(
+            axis == 'X' || axis == 'Y' || axis == 'Z',
+            "Axis must be 'X', 'Y', or 'Z'"
+        );
+        self.axis = axis;
+        self
+    }
+
+    pub fn with_scale(mut self, scale: f64) -> Self {
+        self.scale = scale;
+        self
+    }
+
+    pub fn with_repetitions(mut self, repetitions: usize) -> Self {
+        self.repetitions = repetitions;
+        self
+    }
+}
+
+impl DataEncoder for AngleEncoding {
+    fn encode(&self, circuit: &mut Circuit, data: &[f64]) {
+        let num_qubits = circuit.num_qubits();
+
+        for _ in 0..self.repetitions {
+            for (i, &value) in data.iter().enumerate() {
+                if i >= num_qubits {
+                    break;
+                }
+                let angle = self.scale * value;
+                match self.axis {
+                    'X' => circuit.rx(i, angle),
+                    'Y' => circuit.ry(i, angle),
+                    'Z' => circuit.rz(i, angle),
+                    _ => unreachable!(),
+                };
+            }
+        }
+    }
+
+    fn required_qubits(&self, data_size: usize) -> usize {
+        data_size
+    }
+}
+
+/// Amplitude encoding: encodes data as amplitudes of the quantum state
+///
+/// The classical data vector is normalized and encoded as the amplitudes
+/// of a quantum state. This requires O(log n) qubits for n data points.
+///
+/// For data vector x = [x_0, x_1, ..., x_{n-1}]:
+///   |ψ⟩ = Σᵢ (xᵢ/‖x‖) |i⟩
+#[derive(Clone, Debug)]
+pub struct AmplitudeEncoding;
+
+impl AmplitudeEncoding {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Compute the number of qubits needed for amplitude encoding
+    fn compute_qubits(data_size: usize) -> usize {
+        if data_size <= 1 {
+            1
+        } else {
+            (data_size as f64).log2().ceil() as usize
+        }
+    }
+}
+
+impl Default for AmplitudeEncoding {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DataEncoder for AmplitudeEncoding {
+    fn encode(&self, circuit: &mut Circuit, data: &[f64]) {
+        // Amplitude encoding requires state preparation which is more complex
+        // For simplicity, we use an approximation via rotation gates
+        // that works for small data sizes
+
+        let num_qubits = circuit.num_qubits();
+        let _data_size = data.len();
+
+        // Normalize data
+        let norm: f64 = data.iter().map(|x| x * x).sum::<f64>().sqrt();
+        let normalized: Vec<f64> = if norm > 1e-10 {
+            data.iter().map(|x| x / norm).collect()
+        } else {
+            vec![0.0; data.len()]
+        };
+
+        // For amplitude encoding, we use a simplified approach with RY gates
+        // This is an approximation - full amplitude encoding requires more complex circuits
+        for i in 0..num_qubits.min(normalized.len()) {
+            // Map normalized value to angle
+            // For values in [-1, 1], we use asin to get the angle
+            let clamped = normalized[i].clamp(-1.0, 1.0);
+            let angle = 2.0 * clamped.asin();
+            circuit.ry(i, angle);
+        }
+    }
+
+    fn required_qubits(&self, data_size: usize) -> usize {
+        Self::compute_qubits(data_size)
+    }
+}
+
+/// IQP (Instantaneous Quantum Polynomial) encoding
+///
+/// A more expressive encoding that uses entangling gates between qubits.
+/// This encoding can capture correlations in the data.
+#[derive(Clone, Debug)]
+pub struct IQPEncoding {
+    /// Depth of the encoding circuit
+    pub depth: usize,
+}
+
+impl IQPEncoding {
+    pub fn new(depth: usize) -> Self {
+        Self { depth }
+    }
+}
+
+impl Default for IQPEncoding {
+    fn default() -> Self {
+        Self { depth: 1 }
+    }
+}
+
+impl DataEncoder for IQPEncoding {
+    fn encode(&self, circuit: &mut Circuit, data: &[f64]) {
+        let num_qubits = circuit.num_qubits();
+
+        for _ in 0..self.depth {
+            // Layer of Hadamards
+            for q in 0..num_qubits {
+                circuit.h(q);
+            }
+
+            // Single-qubit Z rotations with data
+            for (i, &value) in data.iter().enumerate() {
+                if i >= num_qubits {
+                    break;
+                }
+                circuit.rz(i, PI * value);
+            }
+
+            // Entangling ZZ interactions with data products
+            for i in 0..num_qubits.saturating_sub(1) {
+                let i_data = if i < data.len() { data[i] } else { 0.0 };
+                let j_data = if i + 1 < data.len() {
+                    data[i + 1]
+                } else {
+                    0.0
+                };
+                circuit.rzz(i, i + 1, PI * i_data * j_data);
+            }
+        }
+    }
+
+    fn required_qubits(&self, data_size: usize) -> usize {
+        data_size
+    }
+}
+
+/// Creates a data encoding circuit with initial superposition
+///
+/// # Arguments
+/// * `num_qubits` - Number of qubits
+/// * `data` - Classical data to encode
+/// * `encoder` - The encoding strategy to use
+///
+/// # Returns
+/// A circuit with the encoded data
+pub fn create_encoding_circuit<E: DataEncoder>(
+    num_qubits: usize,
+    data: &[f64],
+    encoder: &E,
+) -> Circuit {
+    let mut circuit = Circuit::new(num_qubits);
+    encoder.encode(&mut circuit, data);
+    circuit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_angle_encoding() {
+        let encoder = AngleEncoding::new();
+        let mut circuit = Circuit::new(3);
+
+        encoder.encode(&mut circuit, &[0.5, -0.3, 0.8]);
+
+        assert_eq!(circuit.num_operations(), 3);
+    }
+
+    #[test]
+    fn test_amplitude_encoding() {
+        let encoder = AmplitudeEncoding::new();
+        let mut circuit = Circuit::new(3);
+
+        encoder.encode(&mut circuit, &[0.5, 0.5, 0.5]);
+
+        assert!(circuit.num_operations() > 0);
+    }
+
+    #[test]
+    fn test_iqp_encoding() {
+        let encoder = IQPEncoding::new(2);
+        let mut circuit = Circuit::new(3);
+
+        encoder.encode(&mut circuit, &[0.1, 0.2, 0.3]);
+
+        // Should have H gates, RZ gates, and RZZ gates
+        assert!(circuit.num_operations() > 3);
+    }
+
+    #[test]
+    fn test_required_qubits() {
+        let angle = AngleEncoding::new();
+        assert_eq!(angle.required_qubits(4), 4);
+
+        let amplitude = AmplitudeEncoding::new();
+        assert_eq!(amplitude.required_qubits(4), 2); // log2(4) = 2
+        assert_eq!(amplitude.required_qubits(5), 3); // ceil(log2(5)) = 3
+    }
+}

--- a/src/qml/mod.rs
+++ b/src/qml/mod.rs
@@ -1,0 +1,39 @@
+//! Quantum Machine Learning module
+//!
+//! This module provides quantum machine learning components including:
+//! - Quantum Long Short-Term Memory (QLSTM)
+//! - Variational Quantum Circuits for ML
+//! - Data encoding strategies
+//!
+//! Based on:
+//! - "Quantum Long Short-Term Memory" (arXiv:2009.01783) by Chen et al.
+//! - PennyLane's quantum neural network implementations
+//!
+//! # Example: QLSTM for Sequence Prediction
+//!
+//! ```rust
+//! use logosq::qml::{QLSTM, QLSTMConfig};
+//!
+//! // Create a QLSTM with input size 1, hidden size 2
+//! let config = QLSTMConfig::new(1, 2).with_num_layers(1);
+//! let qlstm = QLSTM::new(config);
+//!
+//! // Initialize parameters (randomly in practice)
+//! let num_params = qlstm.num_parameters();
+//! let params: Vec<f64> = (0..num_params).map(|i| (i as f64) * 0.01).collect();
+//!
+//! // Process a sequence
+//! let sequence = vec![vec![0.1], vec![0.2], vec![0.3]];
+//! let output = qlstm.forward(&sequence, &params, None, None);
+//!
+//! println!("Output: {:?}", output);
+//! ```
+
+pub mod data_encoding;
+pub mod qlstm;
+pub mod vqc;
+
+// Re-exports for convenience
+pub use data_encoding::{AmplitudeEncoding, AngleEncoding, DataEncoder, IQPEncoding};
+pub use qlstm::{cross_entropy_loss, mse_loss, QLSTMCell, QLSTMConfig, QLSTMOutput, QLSTMTrainer, QLSTM};
+pub use vqc::{DressedVQC, VQCBuilder, VQCType, VariationalQuantumCircuit};

--- a/src/qml/mod.rs
+++ b/src/qml/mod.rs
@@ -35,5 +35,5 @@ pub mod vqc;
 
 // Re-exports for convenience
 pub use data_encoding::{AmplitudeEncoding, AngleEncoding, DataEncoder, IQPEncoding};
-pub use qlstm::{cross_entropy_loss, mse_loss, QLSTMCell, QLSTMConfig, QLSTMOutput, QLSTMTrainer, QLSTM};
+pub use qlstm::{cross_entropy_loss, cross_entropy_loss_probabilities, mse_loss, QLSTMCell, QLSTMConfig, QLSTMOutput, QLSTMTrainer, QLSTM};
 pub use vqc::{DressedVQC, VQCBuilder, VQCType, VariationalQuantumCircuit};

--- a/src/qml/qlstm.rs
+++ b/src/qml/qlstm.rs
@@ -679,7 +679,7 @@ impl QLSTMTrainer {
     /// * `initial_params` - Initial parameters
     ///
     /// # Returns
-    /// Optimized parameters and final loss
+    /// Tuple of (best parameters, best loss) - the parameters that achieved the lowest loss
     pub fn train(
         &self,
         qlstm: &QLSTM,
@@ -689,6 +689,7 @@ impl QLSTMTrainer {
     ) -> (Vec<f64>, f64) {
         let mut params = initial_params.to_vec();
         let mut best_loss = f64::INFINITY;
+        let mut best_params = params.clone();
 
         for iteration in 0..self.max_iterations {
             // Forward pass
@@ -697,6 +698,7 @@ impl QLSTMTrainer {
 
             if loss < best_loss {
                 best_loss = loss;
+                best_params = params.clone();
             }
 
             // Check convergence
@@ -720,7 +722,7 @@ impl QLSTMTrainer {
             }
         }
 
-        (params, best_loss)
+        (best_params, best_loss)
     }
 }
 

--- a/src/qml/qlstm.rs
+++ b/src/qml/qlstm.rs
@@ -1,0 +1,743 @@
+//! Quantum Long Short-Term Memory (QLSTM)
+//!
+//! Implementation based on Figure 5 from:
+//! - "Quantum Long Short-Term Memory" (arXiv:2009.01783) by Chen et al.
+//! - PennyLane's Learning to Learn with Quantum Neural Networks
+//!
+//! The QLSTM replaces classical LSTM gates with variational quantum circuits,
+//! creating a hybrid quantum-classical recurrent neural network for sequence modeling.
+//!
+//! # Architecture (6 VQCs as per Figure 5)
+//!
+//! The QLSTM cell contains 6 VQCs:
+//!
+//! ## Gate VQCs (VQC₁-VQC₄)
+//! - VQC₁ (Forget): f_t = σ(VQC₁([h_{t-1}, x_t]; θ₁))
+//! - VQC₂ (Input):  i_t = σ(VQC₂([h_{t-1}, x_t]; θ₂))
+//! - VQC₃ (Cell):   c̃_t = tanh(VQC₃([h_{t-1}, x_t]; θ₃))
+//! - VQC₄ (Output): o_t = σ(VQC₄([h_{t-1}, x_t]; θ₄))
+//!
+//! ## Cell state update (classical)
+//! - c_t = f_t ⊙ c_{t-1} + i_t ⊙ c̃_t
+//!
+//! ## Hidden state processing (VQC₅)
+//! - h_t = VQC₅(o_t ⊙ tanh(c_t); θ₅)
+//!
+//! ## Output processing (VQC₆)
+//! - y_t = VQC₆(h_t; θ₆)
+
+use super::vqc::{VQCType, VariationalQuantumCircuit};
+use std::f64::consts::PI;
+
+/// Configuration for QLSTM
+#[derive(Clone, Debug)]
+pub struct QLSTMConfig {
+    /// Number of qubits used for each VQC gate
+    pub num_qubits: usize,
+    /// Number of VQC layers per gate
+    pub num_layers: usize,
+    /// Input feature dimension
+    pub input_size: usize,
+    /// Hidden state dimension
+    pub hidden_size: usize,
+    /// Type of VQC to use
+    pub vqc_type: VQCType,
+    /// Whether to use classical pre-processing (data re-uploading)
+    pub use_classical_preprocessing: bool,
+}
+
+impl Default for QLSTMConfig {
+    fn default() -> Self {
+        Self {
+            num_qubits: 4,
+            num_layers: 2,
+            input_size: 1,
+            hidden_size: 4,
+            vqc_type: VQCType::BasicEntangling,
+            use_classical_preprocessing: true,
+        }
+    }
+}
+
+impl QLSTMConfig {
+    pub fn new(input_size: usize, hidden_size: usize) -> Self {
+        // Number of qubits should accommodate input + hidden state
+        let num_qubits = (input_size + hidden_size).max(2);
+        Self {
+            num_qubits,
+            num_layers: 2,
+            input_size,
+            hidden_size,
+            vqc_type: VQCType::BasicEntangling,
+            use_classical_preprocessing: true,
+        }
+    }
+
+    pub fn with_num_layers(mut self, num_layers: usize) -> Self {
+        self.num_layers = num_layers;
+        self
+    }
+
+    pub fn with_num_qubits(mut self, num_qubits: usize) -> Self {
+        self.num_qubits = num_qubits;
+        self
+    }
+
+    pub fn with_vqc_type(mut self, vqc_type: VQCType) -> Self {
+        self.vqc_type = vqc_type;
+        self
+    }
+}
+
+/// Output of a QLSTM cell
+#[derive(Clone, Debug)]
+pub struct QLSTMOutput {
+    /// Hidden state h_t
+    pub hidden_state: Vec<f64>,
+    /// Cell state c_t
+    pub cell_state: Vec<f64>,
+    /// Raw output before any post-processing
+    pub output: Vec<f64>,
+}
+
+/// A single QLSTM cell
+///
+/// The cell contains six VQCs as shown in Figure 5 of arXiv:2009.01783:
+/// - VQC₁: Forget gate VQC
+/// - VQC₂: Input gate VQC
+/// - VQC₃: Cell gate VQC
+/// - VQC₄: Output gate VQC
+/// - VQC₅: Hidden state processing VQC (processes o_t ⊙ tanh(c_t) → h_t)
+/// - VQC₆: Output processing VQC (processes h_t → y_t)
+#[derive(Clone, Debug)]
+pub struct QLSTMCell {
+    pub config: QLSTMConfig,
+    /// VQC₁: Forget gate
+    vqc_forget: VariationalQuantumCircuit,
+    /// VQC₂: Input gate
+    vqc_input: VariationalQuantumCircuit,
+    /// VQC₃: Cell gate
+    vqc_cell: VariationalQuantumCircuit,
+    /// VQC₄: Output gate
+    vqc_output: VariationalQuantumCircuit,
+    /// VQC₅: Hidden state processing
+    vqc_hidden: VariationalQuantumCircuit,
+    /// VQC₆: Output processing (for y_t)
+    vqc_output_proc: VariationalQuantumCircuit,
+}
+
+impl QLSTMCell {
+    /// Create a new QLSTM cell with 6 VQCs as per Figure 5 of arXiv:2009.01783
+    pub fn new(config: QLSTMConfig) -> Self {
+        // VQC₁: Forget gate
+        let vqc_forget = VariationalQuantumCircuit {
+            num_qubits: config.num_qubits,
+            num_layers: config.num_layers,
+            vqc_type: config.vqc_type.clone(),
+            include_input_encoding: true,
+        };
+        // VQC₂: Input gate
+        let vqc_input = VariationalQuantumCircuit {
+            num_qubits: config.num_qubits,
+            num_layers: config.num_layers,
+            vqc_type: config.vqc_type.clone(),
+            include_input_encoding: true,
+        };
+        // VQC₃: Cell gate
+        let vqc_cell = VariationalQuantumCircuit {
+            num_qubits: config.num_qubits,
+            num_layers: config.num_layers,
+            vqc_type: config.vqc_type.clone(),
+            include_input_encoding: true,
+        };
+        // VQC₄: Output gate
+        let vqc_output = VariationalQuantumCircuit {
+            num_qubits: config.num_qubits,
+            num_layers: config.num_layers,
+            vqc_type: config.vqc_type.clone(),
+            include_input_encoding: true,
+        };
+        // VQC₅: Hidden state processing (uses hidden_size qubits)
+        let vqc_hidden = VariationalQuantumCircuit {
+            num_qubits: config.hidden_size.max(2),
+            num_layers: config.num_layers,
+            vqc_type: config.vqc_type.clone(),
+            include_input_encoding: true,
+        };
+        // VQC₆: Output processing (uses hidden_size qubits)
+        let vqc_output_proc = VariationalQuantumCircuit {
+            num_qubits: config.hidden_size.max(2),
+            num_layers: config.num_layers,
+            vqc_type: config.vqc_type.clone(),
+            include_input_encoding: true,
+        };
+
+        Self {
+            config,
+            vqc_forget,
+            vqc_input,
+            vqc_cell,
+            vqc_output,
+            vqc_hidden,
+            vqc_output_proc,
+        }
+    }
+
+    /// Get the number of parameters for a single gate VQC (VQC₁-VQC₄)
+    pub fn params_per_gate(&self) -> usize {
+        self.vqc_forget.num_variational_params()
+    }
+
+    /// Get the number of parameters for VQC₅ (hidden state processing)
+    pub fn params_vqc_hidden(&self) -> usize {
+        self.vqc_hidden.num_variational_params()
+    }
+
+    /// Get the number of parameters for VQC₆ (output processing)
+    pub fn params_vqc_output_proc(&self) -> usize {
+        self.vqc_output_proc.num_variational_params()
+    }
+
+    /// Get total number of parameters (all six VQCs)
+    pub fn num_parameters(&self) -> usize {
+        4 * self.params_per_gate() + self.params_vqc_hidden() + self.params_vqc_output_proc()
+    }
+
+    /// Split parameters into six VQC parameter sets
+    #[allow(clippy::type_complexity)]
+    fn split_params<'a>(
+        &self,
+        params: &'a [f64],
+    ) -> (
+        &'a [f64],
+        &'a [f64],
+        &'a [f64],
+        &'a [f64],
+        &'a [f64],
+        &'a [f64],
+    ) {
+        let n_gate = self.params_per_gate();
+        let n_hidden = self.params_vqc_hidden();
+        let n_output_proc = self.params_vqc_output_proc();
+
+        let params_f = &params[0..n_gate];
+        let params_i = &params[n_gate..2 * n_gate];
+        let params_c = &params[2 * n_gate..3 * n_gate];
+        let params_o = &params[3 * n_gate..4 * n_gate];
+        let params_h = &params[4 * n_gate..4 * n_gate + n_hidden];
+        let params_y = &params[4 * n_gate + n_hidden..4 * n_gate + n_hidden + n_output_proc];
+
+        (params_f, params_i, params_c, params_o, params_h, params_y)
+    }
+
+    /// Prepare input for VQC: concatenate input and hidden state
+    fn prepare_vqc_input(&self, input: &[f64], hidden: &[f64]) -> Vec<f64> {
+        let mut combined = Vec::with_capacity(self.config.num_qubits);
+
+        // Add input features
+        for &x in input.iter().take(self.config.input_size) {
+            combined.push(x);
+        }
+
+        // Add hidden state
+        for &h in hidden.iter().take(self.config.hidden_size) {
+            combined.push(h);
+        }
+
+        // Pad with zeros if needed
+        while combined.len() < self.config.num_qubits {
+            combined.push(0.0);
+        }
+
+        // Truncate if too long
+        combined.truncate(self.config.num_qubits);
+
+        combined
+    }
+
+    /// Sigmoid activation function
+    fn sigmoid(x: f64) -> f64 {
+        1.0 / (1.0 + (-x).exp())
+    }
+
+    /// Apply sigmoid to a vector
+    fn sigmoid_vec(v: &[f64]) -> Vec<f64> {
+        v.iter().map(|&x| Self::sigmoid(x)).collect()
+    }
+
+    /// Apply tanh to a vector
+    fn tanh_vec(v: &[f64]) -> Vec<f64> {
+        v.iter().map(|&x| x.tanh()).collect()
+    }
+
+    /// Element-wise multiplication
+    fn hadamard_product(a: &[f64], b: &[f64]) -> Vec<f64> {
+        a.iter().zip(b.iter()).map(|(&x, &y)| x * y).collect()
+    }
+
+    /// Element-wise addition
+    fn add_vec(a: &[f64], b: &[f64]) -> Vec<f64> {
+        a.iter().zip(b.iter()).map(|(&x, &y)| x + y).collect()
+    }
+
+    /// Forward pass through the QLSTM cell
+    ///
+    /// Implements the full 6-VQC architecture from Figure 5 of arXiv:2009.01783:
+    /// - VQC₁-VQC₄: Compute gate values (forget, input, cell, output)
+    /// - VQC₅: Process o_t ⊙ tanh(c_t) → h_t (hidden state)
+    /// - VQC₆: Process h_t → y_t (output)
+    ///
+    /// # Arguments
+    /// * `input` - Input vector x_t
+    /// * `hidden_state` - Previous hidden state h_{t-1}
+    /// * `cell_state` - Previous cell state c_{t-1}
+    /// * `params` - All VQC parameters (concatenated: VQC₁, VQC₂, VQC₃, VQC₄, VQC₅, VQC₆)
+    ///
+    /// # Returns
+    /// New hidden state h_t, cell state c_t, and output y_t
+    pub fn forward(
+        &self,
+        input: &[f64],
+        hidden_state: &[f64],
+        cell_state: &[f64],
+        params: &[f64],
+    ) -> QLSTMOutput {
+        assert_eq!(
+            params.len(),
+            self.num_parameters(),
+            "Parameter count mismatch: expected {}, got {}",
+            self.num_parameters(),
+            params.len()
+        );
+
+        // Split parameters for all 6 VQCs
+        let (params_f, params_i, params_c, params_o, params_h, params_y) = self.split_params(params);
+
+        // Prepare input for VQC₁-VQC₄: concatenate [x_t, h_{t-1}]
+        let vqc_input_data = self.prepare_vqc_input(input, hidden_state);
+
+        // ============ VQC₁-VQC₄: Compute gate values ============
+        // The VQC outputs are in [-1, 1] (Z expectation values)
+        let f_raw = self.vqc_forget.forward(&vqc_input_data, params_f);
+        let i_raw = self.vqc_input.forward(&vqc_input_data, params_i);
+        let c_raw = self.vqc_cell.forward(&vqc_input_data, params_c);
+        let o_raw = self.vqc_output.forward(&vqc_input_data, params_o);
+
+        // Apply activations
+        // f_t = σ(VQC₁)
+        let f_t = Self::sigmoid_vec(&f_raw);
+        // i_t = σ(VQC₂)
+        let i_t = Self::sigmoid_vec(&i_raw);
+        // c̃_t = tanh(VQC₃)
+        let c_tilde = Self::tanh_vec(&c_raw);
+        // o_t = σ(VQC₄)
+        let o_t = Self::sigmoid_vec(&o_raw);
+
+        // Ensure vectors have correct size (hidden_size)
+        let f_t: Vec<f64> = f_t.into_iter().take(self.config.hidden_size).collect();
+        let i_t: Vec<f64> = i_t.into_iter().take(self.config.hidden_size).collect();
+        let c_tilde: Vec<f64> = c_tilde.into_iter().take(self.config.hidden_size).collect();
+        let o_t: Vec<f64> = o_t.into_iter().take(self.config.hidden_size).collect();
+
+        // Ensure cell_state has correct size
+        let cell_state: Vec<f64> = cell_state
+            .iter()
+            .take(self.config.hidden_size)
+            .copied()
+            .chain(std::iter::repeat(0.0))
+            .take(self.config.hidden_size)
+            .collect();
+
+        // ============ Cell state update (classical) ============
+        // c_t = f_t ⊙ c_{t-1} + i_t ⊙ c̃_t
+        let forget_contribution = Self::hadamard_product(&f_t, &cell_state);
+        let input_contribution = Self::hadamard_product(&i_t, &c_tilde);
+        let c_t = Self::add_vec(&forget_contribution, &input_contribution);
+
+        // ============ Intermediate: o_t ⊙ tanh(c_t) ============
+        let tanh_c_t = Self::tanh_vec(&c_t);
+        let pre_hidden = Self::hadamard_product(&o_t, &tanh_c_t);
+
+        // ============ VQC₅: Hidden state processing ============
+        // h_t = VQC₅(o_t ⊙ tanh(c_t))
+        let h_t_raw = self.vqc_hidden.forward(&pre_hidden, params_h);
+        let h_t: Vec<f64> = h_t_raw.into_iter().take(self.config.hidden_size).collect();
+
+        // ============ VQC₆: Output processing ============
+        // y_t = VQC₆(h_t)
+        let y_t_raw = self.vqc_output_proc.forward(&h_t, params_y);
+        let y_t: Vec<f64> = y_t_raw.into_iter().take(self.config.hidden_size).collect();
+
+        QLSTMOutput {
+            hidden_state: h_t,
+            cell_state: c_t,
+            output: y_t,
+        }
+    }
+}
+
+/// Full QLSTM layer for sequence processing
+///
+/// Processes a sequence of inputs through one or more QLSTM cells.
+#[derive(Clone, Debug)]
+pub struct QLSTM {
+    /// The QLSTM cell
+    cell: QLSTMCell,
+    /// Whether to return sequences or just the final output
+    return_sequences: bool,
+    /// Number of LSTM layers (stacked)
+    num_layers: usize,
+}
+
+impl QLSTM {
+    /// Create a new QLSTM layer
+    pub fn new(config: QLSTMConfig) -> Self {
+        Self {
+            cell: QLSTMCell::new(config),
+            return_sequences: false,
+            num_layers: 1,
+        }
+    }
+
+    /// Create QLSTM with specified return behavior
+    pub fn with_return_sequences(mut self, return_sequences: bool) -> Self {
+        self.return_sequences = return_sequences;
+        self
+    }
+
+    /// Create stacked QLSTM
+    pub fn with_num_layers(mut self, num_layers: usize) -> Self {
+        self.num_layers = num_layers;
+        self
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &QLSTMConfig {
+        &self.cell.config
+    }
+
+    /// Get total number of parameters
+    pub fn num_parameters(&self) -> usize {
+        self.cell.num_parameters() * self.num_layers
+    }
+
+    /// Get the hidden size
+    pub fn hidden_size(&self) -> usize {
+        self.cell.config.hidden_size
+    }
+
+    /// Initialize hidden and cell states
+    pub fn init_states(&self) -> (Vec<f64>, Vec<f64>) {
+        let hidden = vec![0.0; self.cell.config.hidden_size];
+        let cell = vec![0.0; self.cell.config.hidden_size];
+        (hidden, cell)
+    }
+
+    /// Process a single time step
+    pub fn step(
+        &self,
+        input: &[f64],
+        hidden_state: &[f64],
+        cell_state: &[f64],
+        params: &[f64],
+    ) -> QLSTMOutput {
+        self.cell.forward(input, hidden_state, cell_state, params)
+    }
+
+    /// Process an entire sequence
+    ///
+    /// # Arguments
+    /// * `sequence` - Vector of input vectors, one per time step
+    /// * `params` - VQC parameters
+    /// * `initial_hidden` - Optional initial hidden state
+    /// * `initial_cell` - Optional initial cell state
+    ///
+    /// # Returns
+    /// If return_sequences is true: all hidden states
+    /// If return_sequences is false: only the final hidden state
+    pub fn forward(
+        &self,
+        sequence: &[Vec<f64>],
+        params: &[f64],
+        initial_hidden: Option<&[f64]>,
+        initial_cell: Option<&[f64]>,
+    ) -> Vec<Vec<f64>> {
+        let (h0, c0) = self.init_states();
+        let mut h_t = initial_hidden.unwrap_or(&h0).to_vec();
+        let mut c_t = initial_cell.unwrap_or(&c0).to_vec();
+
+        let mut outputs = Vec::new();
+
+        for input in sequence {
+            let output = self.step(input, &h_t, &c_t, params);
+            h_t = output.hidden_state;
+            c_t = output.cell_state;
+
+            if self.return_sequences {
+                outputs.push(output.output);
+            }
+        }
+
+        if self.return_sequences {
+            outputs
+        } else {
+            vec![h_t]
+        }
+    }
+
+    /// Compute gradient using parameter-shift rule
+    ///
+    /// This computes the gradient of a loss function with respect to VQC parameters.
+    ///
+    /// # Arguments
+    /// * `sequence` - Input sequence
+    /// * `target` - Target output
+    /// * `params` - Current parameters
+    /// * `loss_fn` - Loss function that takes (output, target) and returns a scalar
+    pub fn compute_gradient<F>(
+        &self,
+        sequence: &[Vec<f64>],
+        target: &[f64],
+        params: &[f64],
+        loss_fn: F,
+    ) -> Vec<f64>
+    where
+        F: Fn(&[f64], &[f64]) -> f64,
+    {
+        let num_params = params.len();
+        let mut gradient = vec![0.0; num_params];
+        let shift = PI / 2.0;
+
+        for i in 0..num_params {
+            // Forward shift
+            let mut params_plus = params.to_vec();
+            params_plus[i] += shift;
+            let output_plus = self.forward(sequence, &params_plus, None, None);
+            let loss_plus = loss_fn(&output_plus[0], target);
+
+            // Backward shift
+            let mut params_minus = params.to_vec();
+            params_minus[i] -= shift;
+            let output_minus = self.forward(sequence, &params_minus, None, None);
+            let loss_minus = loss_fn(&output_minus[0], target);
+
+            // Parameter-shift rule
+            gradient[i] = (loss_plus - loss_minus) / 2.0;
+        }
+
+        gradient
+    }
+}
+
+/// Mean squared error loss
+pub fn mse_loss(output: &[f64], target: &[f64]) -> f64 {
+    let n = output.len().min(target.len());
+    if n == 0 {
+        return 0.0;
+    }
+
+    output
+        .iter()
+        .zip(target.iter())
+        .map(|(&o, &t)| (o - t).powi(2))
+        .sum::<f64>()
+        / n as f64
+}
+
+/// Cross-entropy loss (for classification)
+pub fn cross_entropy_loss(output: &[f64], target: &[f64]) -> f64 {
+    let epsilon = 1e-10;
+    let n = output.len().min(target.len());
+    if n == 0 {
+        return 0.0;
+    }
+
+    -output
+        .iter()
+        .zip(target.iter())
+        .map(|(&o, &t)| {
+            let o_clamped = o.clamp(epsilon, 1.0 - epsilon);
+            t * o_clamped.ln() + (1.0 - t) * (1.0 - o_clamped).ln()
+        })
+        .sum::<f64>()
+        / n as f64
+}
+
+/// A simple training helper for QLSTM
+pub struct QLSTMTrainer {
+    pub learning_rate: f64,
+    pub max_iterations: usize,
+    pub tolerance: f64,
+    pub verbose: bool,
+}
+
+impl Default for QLSTMTrainer {
+    fn default() -> Self {
+        Self {
+            learning_rate: 0.01,
+            max_iterations: 100,
+            tolerance: 1e-6,
+            verbose: true,
+        }
+    }
+}
+
+impl QLSTMTrainer {
+    pub fn new(learning_rate: f64, max_iterations: usize) -> Self {
+        Self {
+            learning_rate,
+            max_iterations,
+            tolerance: 1e-6,
+            verbose: true,
+        }
+    }
+
+    /// Train the QLSTM on a single sequence
+    ///
+    /// # Arguments
+    /// * `qlstm` - The QLSTM model
+    /// * `sequence` - Training sequence
+    /// * `target` - Target output
+    /// * `initial_params` - Initial parameters
+    ///
+    /// # Returns
+    /// Optimized parameters and final loss
+    pub fn train(
+        &self,
+        qlstm: &QLSTM,
+        sequence: &[Vec<f64>],
+        target: &[f64],
+        initial_params: &[f64],
+    ) -> (Vec<f64>, f64) {
+        let mut params = initial_params.to_vec();
+        let mut best_loss = f64::INFINITY;
+
+        for iteration in 0..self.max_iterations {
+            // Forward pass
+            let output = qlstm.forward(sequence, &params, None, None);
+            let loss = mse_loss(&output[0], target);
+
+            if loss < best_loss {
+                best_loss = loss;
+            }
+
+            // Check convergence
+            if loss < self.tolerance {
+                if self.verbose {
+                    println!("Converged at iteration {}: loss = {:.6}", iteration, loss);
+                }
+                break;
+            }
+
+            // Compute gradient
+            let gradient = qlstm.compute_gradient(sequence, target, &params, mse_loss);
+
+            // Update parameters (gradient descent)
+            for (p, g) in params.iter_mut().zip(gradient.iter()) {
+                *p -= self.learning_rate * g;
+            }
+
+            if self.verbose && iteration % 10 == 0 {
+                println!("Iteration {}: loss = {:.6}", iteration, loss);
+            }
+        }
+
+        (params, best_loss)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_qlstm_cell_creation() {
+        let config = QLSTMConfig::new(2, 4);
+        let cell = QLSTMCell::new(config);
+
+        assert_eq!(cell.config.input_size, 2);
+        assert_eq!(cell.config.hidden_size, 4);
+    }
+
+    #[test]
+    fn test_qlstm_cell_forward() {
+        let config = QLSTMConfig::new(2, 4).with_num_layers(1);
+        let cell = QLSTMCell::new(config);
+
+        let num_params = cell.num_parameters();
+        let params: Vec<f64> = (0..num_params).map(|i| (i as f64) * 0.01).collect();
+
+        let input = vec![0.5, 0.3];
+        let hidden = vec![0.0; 4];
+        let cell_state = vec![0.0; 4];
+
+        let output = cell.forward(&input, &hidden, &cell_state, &params);
+
+        assert_eq!(output.hidden_state.len(), 4);
+        assert_eq!(output.cell_state.len(), 4);
+        assert_eq!(output.output.len(), 4);
+    }
+
+    #[test]
+    fn test_qlstm_sequence() {
+        let config = QLSTMConfig::new(1, 2).with_num_layers(1);
+        let qlstm = QLSTM::new(config);
+
+        let num_params = qlstm.num_parameters();
+        let params: Vec<f64> = (0..num_params).map(|i| (i as f64) * 0.01).collect();
+
+        let sequence = vec![vec![0.1], vec![0.2], vec![0.3], vec![0.4]];
+
+        let output = qlstm.forward(&sequence, &params, None, None);
+
+        // Without return_sequences, we get only the final state
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].len(), 2);
+    }
+
+    #[test]
+    fn test_qlstm_return_sequences() {
+        let config = QLSTMConfig::new(1, 2).with_num_layers(1);
+        let qlstm = QLSTM::new(config).with_return_sequences(true);
+
+        let num_params = qlstm.num_parameters();
+        let params: Vec<f64> = (0..num_params).map(|i| (i as f64) * 0.01).collect();
+
+        let sequence = vec![vec![0.1], vec![0.2], vec![0.3], vec![0.4]];
+
+        let output = qlstm.forward(&sequence, &params, None, None);
+
+        // With return_sequences, we get output at each time step
+        assert_eq!(output.len(), 4);
+    }
+
+    #[test]
+    fn test_mse_loss() {
+        let output = vec![0.5, 0.5];
+        let target = vec![1.0, 0.0];
+
+        let loss = mse_loss(&output, &target);
+        // MSE = ((0.5-1)^2 + (0.5-0)^2) / 2 = (0.25 + 0.25) / 2 = 0.25
+        assert!((loss - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_qlstm_gradient() {
+        let config = QLSTMConfig::new(1, 2).with_num_layers(1).with_num_qubits(3);
+        let qlstm = QLSTM::new(config);
+
+        let num_params = qlstm.num_parameters();
+        let params: Vec<f64> = (0..num_params).map(|i| (i as f64) * 0.1).collect();
+
+        let sequence = vec![vec![0.5]];
+        let target = vec![0.3, 0.7];
+
+        let gradient = qlstm.compute_gradient(&sequence, &target, &params, mse_loss);
+
+        assert_eq!(gradient.len(), num_params);
+        // Gradients should be finite
+        for g in &gradient {
+            assert!(g.is_finite());
+        }
+    }
+}

--- a/src/qml/vqc.rs
+++ b/src/qml/vqc.rs
@@ -1,0 +1,344 @@
+//! Variational Quantum Circuit (VQC) for quantum machine learning
+//!
+//! This module provides flexible VQC implementations that can be used
+//! as quantum layers in hybrid quantum-classical models like QLSTM.
+
+use crate::circuits::Circuit;
+use crate::optimization::ansatz::Ansatz;
+use crate::states::State;
+use std::f64::consts::PI;
+
+/// Type of VQC architecture
+#[derive(Clone, Debug, PartialEq)]
+pub enum VQCType {
+    /// Simple VQC with single-qubit rotations only
+    Simple,
+    /// Strongly entangling layers (similar to PennyLane's StronglyEntanglingLayers)
+    StronglyEntangling,
+    /// Basic entangling layers with alternating entanglement
+    BasicEntangling,
+    /// Custom VQC
+    Custom,
+}
+
+/// Builder for Variational Quantum Circuits
+#[derive(Clone, Debug)]
+pub struct VQCBuilder {
+    num_qubits: usize,
+    num_layers: usize,
+    vqc_type: VQCType,
+    include_input_encoding: bool,
+}
+
+impl VQCBuilder {
+    pub fn new(num_qubits: usize) -> Self {
+        Self {
+            num_qubits,
+            num_layers: 1,
+            vqc_type: VQCType::BasicEntangling,
+            include_input_encoding: true,
+        }
+    }
+
+    pub fn with_layers(mut self, num_layers: usize) -> Self {
+        self.num_layers = num_layers;
+        self
+    }
+
+    pub fn with_type(mut self, vqc_type: VQCType) -> Self {
+        self.vqc_type = vqc_type;
+        self
+    }
+
+    pub fn with_input_encoding(mut self, include: bool) -> Self {
+        self.include_input_encoding = include;
+        self
+    }
+
+    pub fn build(self) -> VariationalQuantumCircuit {
+        VariationalQuantumCircuit {
+            num_qubits: self.num_qubits,
+            num_layers: self.num_layers,
+            vqc_type: self.vqc_type,
+            include_input_encoding: self.include_input_encoding,
+        }
+    }
+}
+
+/// A Variational Quantum Circuit for use in quantum neural networks
+///
+/// This circuit structure follows the pattern from the QLSTM paper:
+/// - Input encoding layer (optional)
+/// - Parameterized rotation layers
+/// - Entangling layers
+#[derive(Clone, Debug)]
+pub struct VariationalQuantumCircuit {
+    pub num_qubits: usize,
+    pub num_layers: usize,
+    pub vqc_type: VQCType,
+    pub include_input_encoding: bool,
+}
+
+impl VariationalQuantumCircuit {
+    /// Create a new VQC with default settings
+    pub fn new(num_qubits: usize, num_layers: usize) -> Self {
+        Self {
+            num_qubits,
+            num_layers,
+            vqc_type: VQCType::BasicEntangling,
+            include_input_encoding: true,
+        }
+    }
+
+    /// Get the number of parameters for input encoding
+    pub fn num_input_params(&self) -> usize {
+        if self.include_input_encoding {
+            self.num_qubits
+        } else {
+            0
+        }
+    }
+
+    /// Get the number of variational parameters (excluding inputs)
+    pub fn num_variational_params(&self) -> usize {
+        match self.vqc_type {
+            VQCType::Simple => self.num_qubits * self.num_layers,
+            VQCType::StronglyEntangling => 3 * self.num_qubits * self.num_layers,
+            VQCType::BasicEntangling => 2 * self.num_qubits * self.num_layers,
+            VQCType::Custom => 2 * self.num_qubits * self.num_layers,
+        }
+    }
+
+    /// Build the circuit with given inputs and parameters
+    ///
+    /// # Arguments
+    /// * `inputs` - Input data (for data encoding)
+    /// * `params` - Variational parameters
+    pub fn build_circuit(&self, inputs: &[f64], params: &[f64]) -> Circuit {
+        let mut circuit = Circuit::new(self.num_qubits);
+
+        // Input encoding layer
+        if self.include_input_encoding {
+            for (i, &input) in inputs.iter().enumerate().take(self.num_qubits) {
+                circuit.ry(i, PI * input);
+            }
+        }
+
+        // Variational layers
+        let mut param_idx = 0;
+        for layer in 0..self.num_layers {
+            match self.vqc_type {
+                VQCType::Simple => {
+                    // Simple: only RY rotations
+                    for qubit in 0..self.num_qubits {
+                        circuit.ry(qubit, params[param_idx]);
+                        param_idx += 1;
+                    }
+                }
+                VQCType::StronglyEntangling => {
+                    // Strongly entangling: RZ-RY-RZ on each qubit, then CNOT chain
+                    for qubit in 0..self.num_qubits {
+                        circuit.rz(qubit, params[param_idx]);
+                        param_idx += 1;
+                        circuit.ry(qubit, params[param_idx]);
+                        param_idx += 1;
+                        circuit.rz(qubit, params[param_idx]);
+                        param_idx += 1;
+                    }
+                    // Entangling: CNOT chain with different patterns per layer
+                    let offset = layer % self.num_qubits;
+                    for i in 0..self.num_qubits.saturating_sub(1) {
+                        let control = (i + offset) % self.num_qubits;
+                        let target = (i + 1 + offset) % self.num_qubits;
+                        if control != target {
+                            circuit.cnot(control, target);
+                        }
+                    }
+                }
+                VQCType::BasicEntangling | VQCType::Custom => {
+                    // Basic entangling: RY-RZ on each qubit, then CNOT ladder
+                    for qubit in 0..self.num_qubits {
+                        circuit.ry(qubit, params[param_idx]);
+                        param_idx += 1;
+                        circuit.rz(qubit, params[param_idx]);
+                        param_idx += 1;
+                    }
+                    // Entangling layer
+                    for i in 0..self.num_qubits.saturating_sub(1) {
+                        circuit.cnot(i, i + 1);
+                    }
+                }
+            }
+        }
+
+        circuit
+    }
+
+    /// Execute the VQC and return measurement expectation
+    ///
+    /// # Arguments
+    /// * `inputs` - Input data for encoding
+    /// * `params` - Variational parameters
+    ///
+    /// # Returns
+    /// Vector of expectation values (one per qubit)
+    pub fn forward(&self, inputs: &[f64], params: &[f64]) -> Vec<f64> {
+        let circuit = self.build_circuit(inputs, params);
+        let mut state = State::zero_state(self.num_qubits);
+
+        circuit
+            .execute(&mut state)
+            .expect("Circuit execution failed");
+
+        // Compute Z expectation for each qubit
+        self.measure_expectations(&state)
+    }
+
+    /// Measure expectation values of Z for each qubit
+    fn measure_expectations(&self, state: &State) -> Vec<f64> {
+        let mut expectations = vec![0.0; self.num_qubits];
+
+        let probs = state.probabilities();
+
+        for (basis_idx, prob) in probs.iter().enumerate() {
+            for qubit in 0..self.num_qubits {
+                // Check if this qubit is |1⟩ in this basis state
+                let bit = (basis_idx >> qubit) & 1;
+                // Z eigenvalue: +1 for |0⟩, -1 for |1⟩
+                let eigenvalue = if bit == 0 { 1.0 } else { -1.0 };
+                expectations[qubit] += eigenvalue * prob;
+            }
+        }
+
+        expectations
+    }
+
+    /// Compute the output with a final activation (tanh-like)
+    ///
+    /// Maps the Z expectations from [-1, 1] to a desired range
+    pub fn forward_activated(&self, inputs: &[f64], params: &[f64]) -> Vec<f64> {
+        self.forward(inputs, params)
+    }
+}
+
+impl Ansatz for VariationalQuantumCircuit {
+    fn build_circuit(&self, parameters: &[f64]) -> Circuit {
+        // For Ansatz trait, we use empty inputs (parameters only)
+        self.build_circuit(&[], parameters)
+    }
+
+    fn num_parameters(&self) -> usize {
+        self.num_variational_params()
+    }
+
+    fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+}
+
+/// A dressed quantum circuit (VQC with input scaling and bias)
+///
+/// Output = W * VQC(inputs, params) + b
+///
+/// This provides additional classical expressivity around the quantum circuit.
+#[derive(Clone, Debug)]
+pub struct DressedVQC {
+    pub vqc: VariationalQuantumCircuit,
+    /// Output weights (one per output)
+    pub output_weights: Vec<f64>,
+    /// Output biases (one per output)
+    pub output_biases: Vec<f64>,
+}
+
+impl DressedVQC {
+    pub fn new(vqc: VariationalQuantumCircuit, output_size: usize) -> Self {
+        Self {
+            output_weights: vec![1.0; output_size],
+            output_biases: vec![0.0; output_size],
+            vqc,
+        }
+    }
+
+    /// Forward pass with classical post-processing
+    pub fn forward(&self, inputs: &[f64], params: &[f64]) -> Vec<f64> {
+        let vqc_output = self.vqc.forward(inputs, params);
+
+        vqc_output
+            .iter()
+            .zip(self.output_weights.iter())
+            .zip(self.output_biases.iter())
+            .map(|((v, w), b)| v * w + b)
+            .collect()
+    }
+
+    /// Get total number of trainable parameters
+    pub fn num_params(&self) -> usize {
+        self.vqc.num_variational_params() + self.output_weights.len() + self.output_biases.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vqc_creation() {
+        let vqc = VariationalQuantumCircuit::new(4, 2);
+        assert_eq!(vqc.num_qubits, 4);
+        assert_eq!(vqc.num_layers, 2);
+    }
+
+    #[test]
+    fn test_vqc_builder() {
+        let vqc = VQCBuilder::new(3)
+            .with_layers(2)
+            .with_type(VQCType::StronglyEntangling)
+            .build();
+
+        assert_eq!(vqc.num_qubits, 3);
+        assert_eq!(vqc.num_layers, 2);
+        assert_eq!(vqc.vqc_type, VQCType::StronglyEntangling);
+    }
+
+    #[test]
+    fn test_vqc_forward() {
+        let vqc = VariationalQuantumCircuit::new(2, 1);
+        let inputs = vec![0.5, 0.3];
+        let params = vec![0.1, 0.2, 0.3, 0.4]; // 2 * 2 params for BasicEntangling
+
+        let output = vqc.forward(&inputs, &params);
+
+        assert_eq!(output.len(), 2);
+        // Outputs should be in [-1, 1] for Z expectations
+        for &o in &output {
+            assert!(o >= -1.0 && o <= 1.0);
+        }
+    }
+
+    #[test]
+    fn test_num_params() {
+        let simple = VariationalQuantumCircuit {
+            num_qubits: 3,
+            num_layers: 2,
+            vqc_type: VQCType::Simple,
+            include_input_encoding: true,
+        };
+        assert_eq!(simple.num_variational_params(), 6); // 3 * 2
+
+        let strong = VariationalQuantumCircuit {
+            num_qubits: 3,
+            num_layers: 2,
+            vqc_type: VQCType::StronglyEntangling,
+            include_input_encoding: true,
+        };
+        assert_eq!(strong.num_variational_params(), 18); // 3 * 3 * 2
+
+        let basic = VariationalQuantumCircuit {
+            num_qubits: 3,
+            num_layers: 2,
+            vqc_type: VQCType::BasicEntangling,
+            include_input_encoding: true,
+        };
+        assert_eq!(basic.num_variational_params(), 12); // 2 * 3 * 2
+    }
+}

--- a/src/vis/mod.rs
+++ b/src/vis/mod.rs
@@ -1,6 +1,7 @@
-//! Visualization module for quantum components including circuits, states, gates and noise models.
+//! Visualization module for quantum components including circuits, states, gates, noise models, and QML.
 
 pub mod circuit;
+pub mod qlstm;
 
 // Placeholder modules for future implementation
 pub mod gate;
@@ -11,6 +12,17 @@ pub mod state;
 pub use circuit::{
     save_svg_diagram as save_circuit_svg, svg_diagram as circuit_svg, text_diagram as circuit_text,
     view_circuit,
+};
+
+// Re-export QLSTM visualization functions
+pub use qlstm::{
+    save_svg_diagram as save_qlstm_svg,
+    save_vqc_svg_diagram as save_vqc_svg,
+    svg_diagram as qlstm_svg,
+    text_diagram as qlstm_text,
+    view_qlstm,
+    vqc_svg_diagram as vqc_svg,
+    vqc_text_diagram as vqc_text,
 };
 
 // Main visualization function that determines the type and renders accordingly

--- a/src/vis/qlstm.rs
+++ b/src/vis/qlstm.rs
@@ -346,7 +346,18 @@ pub fn vqc_svg_diagram(vqc: &VariationalQuantumCircuit) -> String {
     let cell_width = 50;
     let cell_height = 40;
     let margin = 60;
-    let num_cols = vqc.num_layers * 3 + (if vqc.include_input_encoding { 2 } else { 1 });
+    
+    // Calculate columns per layer based on VQC type:
+    // - Simple: 1 column (RY only)
+    // - BasicEntangling/Custom: 3 columns (RY + RZ + CNOT ladder)
+    // - StronglyEntangling: 4 columns (RZ + RY + RZ + CNOT chain)
+    let cols_per_layer = match vqc.vqc_type {
+        VQCType::Simple => 1,
+        VQCType::BasicEntangling | VQCType::Custom => 3,
+        VQCType::StronglyEntangling => 4,
+    };
+    // +1 for measurement column, +1 additional if input encoding is included
+    let num_cols = vqc.num_layers * cols_per_layer + (if vqc.include_input_encoding { 2 } else { 1 });
     let width = num_cols * cell_width + 2 * margin;
     let height = vqc.num_qubits * cell_height + 2 * margin + 40;
 

--- a/src/vis/qlstm.rs
+++ b/src/vis/qlstm.rs
@@ -1,0 +1,699 @@
+//! QLSTM visualization module
+//!
+//! This module provides visualization tools for Quantum Long Short-Term Memory (QLSTM)
+//! cells and layers, including SVG diagram generation.
+
+use crate::qml::{QLSTMConfig, VQCType, VariationalQuantumCircuit, QLSTM};
+use std::io::Result;
+
+/// Generate a text-based QLSTM architecture diagram
+pub fn text_diagram(config: &QLSTMConfig) -> String {
+    let mut result = String::new();
+
+    result.push_str("┌─────────────────────────────────────────────────────────────┐\n");
+    result.push_str("│                    QLSTM Cell Architecture                  │\n");
+    result.push_str("├─────────────────────────────────────────────────────────────┤\n");
+    result.push_str("│                                                             │\n");
+    result.push_str("│  ┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐  │\n");
+    result.push_str("│  │  VQC_f  │    │  VQC_i  │    │  VQC_c  │    │  VQC_o  │  │\n");
+    result.push_str("│  │ (Forget)│    │ (Input) │    │ (Cell)  │    │(Output) │  │\n");
+    result.push_str("│  └────┬────┘    └────┬────┘    └────┬────┘    └────┬────┘  │\n");
+    result.push_str("│       │σ            │σ            │tanh          │σ       │\n");
+    result.push_str("│       ▼              ▼              ▼              ▼        │\n");
+    result.push_str("│       ○──────────────○──────────────○──────────────○        │\n");
+    result.push_str("│       │              │              │              │        │\n");
+    result.push_str("│       ▼              ▼              ▼              ▼        │\n");
+    result.push_str("│   ┌───────┐     ┌───────┐     ┌───────┐     ┌───────┐      │\n");
+    result.push_str("│   │  f_t  │     │  i_t  │     │  c̃_t │     │  o_t  │      │\n");
+    result.push_str("│   └───┬───┘     └───┬───┘     └───┬───┘     └───┬───┘      │\n");
+    result.push_str("│       │             │             │             │          │\n");
+    result.push_str("│       └──────┬──────┴──────┬──────┘             │          │\n");
+    result.push_str("│              ▼             ▼                    │          │\n");
+    result.push_str("│         ┌─────────┐   ┌─────────┐               │          │\n");
+    result.push_str("│  c_{t-1}│   ⊙     │   │   ⊙     │               │          │\n");
+    result.push_str("│    ────►│  f_t    │──►│  i_t    │               │          │\n");
+    result.push_str("│         └────┬────┘   └────┬────┘               │          │\n");
+    result.push_str("│              └──────┬──────┘                    │          │\n");
+    result.push_str("│                     ▼                           │          │\n");
+    result.push_str("│                ┌─────────┐                      │          │\n");
+    result.push_str("│                │   c_t   │──────────┐           │          │\n");
+    result.push_str("│                └────┬────┘          │           │          │\n");
+    result.push_str("│                     │              tanh         │          │\n");
+    result.push_str("│                     ▼               ▼           ▼          │\n");
+    result.push_str("│                ┌─────────┐     ┌─────────┐                 │\n");
+    result.push_str("│                │  c_t    │────►│   ⊙     │────► h_t        │\n");
+    result.push_str("│                └─────────┘     └─────────┘                 │\n");
+    result.push_str("│                                                            │\n");
+    result.push_str("├────────────────────────────────────────────────────────────┤\n");
+    result.push_str(&format!(
+        "│  Input size: {}    Hidden size: {}    Qubits: {}    Layers: {}    │\n",
+        config.input_size, config.hidden_size, config.num_qubits, config.num_layers
+    ));
+    result.push_str("└────────────────────────────────────────────────────────────┘\n");
+
+    result
+}
+
+/// Generate a text diagram showing VQC structure
+pub fn vqc_text_diagram(vqc: &VariationalQuantumCircuit) -> String {
+    let mut result = String::new();
+
+    let vqc_type_name = match vqc.vqc_type {
+        VQCType::Simple => "Simple",
+        VQCType::BasicEntangling => "BasicEntangling",
+        VQCType::StronglyEntangling => "StronglyEntangling",
+        VQCType::Custom => "Custom",
+    };
+
+    result.push_str("┌─────────────────────────────────────────┐\n");
+    result.push_str(&format!(
+        "│  VQC: {} ({} qubits, {} layers)  \n",
+        vqc_type_name, vqc.num_qubits, vqc.num_layers
+    ));
+    result.push_str("├─────────────────────────────────────────┤\n");
+
+    // Show input encoding
+    if vqc.include_input_encoding {
+        result.push_str("│  Input Encoding:                        │\n");
+        for q in 0..vqc.num_qubits {
+            result.push_str(&format!("│    q{}: ──RY(πx{})──                    │\n", q, q));
+        }
+        result.push_str("├─────────────────────────────────────────┤\n");
+    }
+
+    // Show variational layers
+    for layer in 0..vqc.num_layers {
+        result.push_str(&format!("│  Layer {}:                              │\n", layer));
+        match vqc.vqc_type {
+            VQCType::Simple => {
+                for q in 0..vqc.num_qubits {
+                    result.push_str(&format!("│    q{}: ──RY(θ)──                       │\n", q));
+                }
+            }
+            VQCType::BasicEntangling | VQCType::Custom => {
+                for q in 0..vqc.num_qubits {
+                    result.push_str(&format!(
+                        "│    q{}: ──RY(θ)──RZ(θ)──                │\n",
+                        q
+                    ));
+                }
+                result.push_str("│    Entangling: CNOT ladder              │\n");
+            }
+            VQCType::StronglyEntangling => {
+                for q in 0..vqc.num_qubits {
+                    result.push_str(&format!(
+                        "│    q{}: ──RZ(θ)──RY(θ)──RZ(θ)──        │\n",
+                        q
+                    ));
+                }
+                result.push_str("│    Entangling: CNOT chain (rotated)    │\n");
+            }
+        }
+        if layer < vqc.num_layers - 1 {
+            result.push_str("├─────────────────────────────────────────┤\n");
+        }
+    }
+
+    result.push_str("├─────────────────────────────────────────┤\n");
+    result.push_str("│  Measurement: Z expectation per qubit   │\n");
+    result.push_str(&format!(
+        "│  Parameters: {}                          │\n",
+        vqc.num_variational_params()
+    ));
+    result.push_str("└─────────────────────────────────────────┘\n");
+
+    result
+}
+
+/// Generate an SVG visualization of the QLSTM cell architecture
+/// Based on Figure 5 from "Quantum Long Short-Term Memory" (arXiv:2009.01783)
+pub fn svg_diagram(config: &QLSTMConfig) -> String {
+    let width = 750;
+    let height = 580;
+
+    let vqc_type_name = match config.vqc_type {
+        VQCType::Simple => "Simple",
+        VQCType::BasicEntangling => "BasicEntangling",
+        VQCType::StronglyEntangling => "StronglyEntangling",
+        VQCType::Custom => "Custom",
+    };
+
+    let mut svg = format!(
+        r##"<svg width="{}" height="{}" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                <polygon points="0 0, 8 3, 0 6" fill="#333"/>
+            </marker>
+        </defs>
+        <style>
+            .title {{ font-family: Arial, sans-serif; font-size: 14px; font-weight: bold; text-anchor: middle; }}
+            .vqc-box {{ fill: #4FC3F7; stroke: #0288D1; stroke-width: 2; }}
+            .input-box {{ fill: #81C784; stroke: #388E3C; stroke-width: 2; }}
+            .output-box {{ fill: #81C784; stroke: #388E3C; stroke-width: 2; }}
+            .postproc-box {{ fill: #4FC3F7; stroke: #0288D1; stroke-width: 2; }}
+            .op-circle {{ fill: #F8BBD9; stroke: #C2185B; stroke-width: 2; }}
+            .activation {{ fill: #F8BBD9; stroke: #C2185B; stroke-width: 1.5; }}
+            .label {{ font-family: Arial, sans-serif; font-size: 11px; text-anchor: middle; dominant-baseline: middle; }}
+            .label-bold {{ font-family: Arial, sans-serif; font-size: 12px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }}
+            .label-italic {{ font-family: Arial, sans-serif; font-size: 11px; font-style: italic; text-anchor: middle; dominant-baseline: middle; }}
+            .small-label {{ font-family: Arial, sans-serif; font-size: 9px; text-anchor: middle; dominant-baseline: middle; }}
+            .arrow {{ stroke: #333; stroke-width: 1.5; fill: none; marker-end: url(#arrowhead); }}
+            .line {{ stroke: #333; stroke-width: 1.5; fill: none; }}
+            .cell-boundary {{ fill: #FFEB3B; fill-opacity: 0.4; stroke: #333; stroke-width: 2; stroke-dasharray: 8,4; }}
+        </style>
+        "##,
+        width, height
+    );
+
+    // Background
+    svg.push_str(r##"<rect x="0" y="0" width="750" height="580" fill="#FFFFFF"/>"##);
+
+    // Title
+    svg.push_str(&format!(
+        r##"<text x="{}" y="20" class="title">QLSTM Cell (arXiv:2009.01783)</text>"##,
+        width / 2
+    ));
+
+    // ============ YELLOW DASHED CELL BOUNDARY ============
+    svg.push_str(r##"<rect x="100" y="120" width="520" height="390" rx="10" class="cell-boundary"/>"##);
+
+    // ============ LEFT SIDE: Inputs (Green boxes) ============
+    // c_{t-1} input (top left)
+    svg.push_str(r##"<rect x="20" y="175" width="55" height="30" rx="8" class="input-box"/>"##);
+    svg.push_str(r##"<text x="47" y="190" class="label-italic">c_{t-1}</text>"##);
+
+    // h_{t-1} input (middle left)  
+    svg.push_str(r##"<rect x="20" y="380" width="55" height="30" rx="8" class="input-box"/>"##);
+    svg.push_str(r##"<text x="47" y="395" class="label-italic">h_{t-1}</text>"##);
+
+    // x_t input (bottom left)
+    svg.push_str(r##"<rect x="20" y="455" width="55" height="30" rx="8" class="input-box"/>"##);
+    svg.push_str(r##"<text x="47" y="470" class="label-italic">x_t</text>"##);
+
+    // ============ RIGHT SIDE: Outputs (Green boxes) ============
+    // c_t output
+    svg.push_str(r##"<rect x="645" y="175" width="55" height="30" rx="8" class="output-box"/>"##);
+    svg.push_str(r##"<text x="672" y="190" class="label-italic">c_t</text>"##);
+
+    // h_t output
+    svg.push_str(r##"<rect x="645" y="310" width="55" height="30" rx="8" class="output-box"/>"##);
+    svg.push_str(r##"<text x="672" y="325" class="label-italic">h_t</text>"##);
+
+    // y_t output
+    svg.push_str(r##"<rect x="645" y="70" width="55" height="30" rx="8" class="output-box"/>"##);
+    svg.push_str(r##"<text x="672" y="85" class="label-italic">y_t</text>"##);
+
+    // ============ VQC BLOCKS (Blue boxes) ============
+    // VQC₁ - Forget gate
+    svg.push_str(r##"<rect x="133" y="420" width="55" height="30" rx="5" class="vqc-box"/>"##);
+    svg.push_str(r##"<text x="160" y="435" class="label-bold">VQC₁</text>"##);
+
+    // VQC₂ - Input gate
+    svg.push_str(r##"<rect x="213" y="420" width="55" height="30" rx="5" class="vqc-box"/>"##);
+    svg.push_str(r##"<text x="240" y="435" class="label-bold">VQC₂</text>"##);
+
+    // VQC₃ - Cell gate
+    svg.push_str(r##"<rect x="293" y="420" width="55" height="30" rx="5" class="vqc-box"/>"##);
+    svg.push_str(r##"<text x="320" y="435" class="label-bold">VQC₃</text>"##);
+
+    // VQC₄ - Output gate
+    svg.push_str(r##"<rect x="373" y="420" width="55" height="30" rx="5" class="vqc-box"/>"##);
+    svg.push_str(r##"<text x="400" y="435" class="label-bold">VQC₄</text>"##);
+
+    // VQC₅ - h_t processing (positioned to receive from third ⊗)
+    svg.push_str(r##"<rect x="533" y="310" width="55" height="30" rx="5" class="vqc-box"/>"##);
+    svg.push_str(r##"<text x="560" y="325" class="label-bold">VQC₅</text>"##);
+
+    // VQC₆ - y_t processing
+    svg.push_str(r##"<rect x="533" y="130" width="55" height="30" rx="5" class="vqc-box"/>"##);
+    svg.push_str(r##"<text x="560" y="145" class="label-bold">VQC₆</text>"##);
+
+    // ============ ACTIVATION FUNCTIONS (Pink circles) ============
+    // σ after VQC₁ (Forget)
+    svg.push_str(r##"<circle cx="160" cy="375" r="15" class="activation"/>"##);
+    svg.push_str(r##"<text x="160" y="375" class="label">σ</text>"##);
+    svg.push_str(r##"<line x1="160" y1="420" x2="160" y2="390" class="arrow"/>"##);
+
+    // σ after VQC₂ (Input)
+    svg.push_str(r##"<circle cx="240" cy="375" r="15" class="activation"/>"##);
+    svg.push_str(r##"<text x="240" y="375" class="label">σ</text>"##);
+    svg.push_str(r##"<line x1="240" y1="420" x2="240" y2="390" class="arrow"/>"##);
+
+    // tanh after VQC₃ (Cell)
+    svg.push_str(r##"<circle cx="320" cy="375" r="15" class="activation"/>"##);
+    svg.push_str(r##"<text x="320" y="375" class="small-label">tanh</text>"##);
+    svg.push_str(r##"<line x1="320" y1="420" x2="320" y2="390" class="arrow"/>"##);
+
+    // σ after VQC₄ (Output)
+    svg.push_str(r##"<circle cx="400" cy="375" r="15" class="activation"/>"##);
+    svg.push_str(r##"<text x="400" y="375" class="label">σ</text>"##);
+    svg.push_str(r##"<line x1="400" y1="420" x2="400" y2="390" class="arrow"/>"##);
+
+    // tanh for c_t → tanh(c_t)
+    svg.push_str(r##"<circle cx="450" cy="250" r="12" class="activation"/>"##);
+    svg.push_str(r##"<text x="450" y="250" class="small-label">tanh</text>"##);
+
+    // ============ MULTIPLICATION OPERATIONS (⊗) ============
+    // First ⊗: c_{t-1} × f_t (forget gate operation)
+    svg.push_str(r##"<circle cx="160" cy="190" r="15" class="op-circle"/>"##);
+    svg.push_str(r##"<text x="160" y="190" class="label-bold">⊗</text>"##);
+    
+    // c_{t-1} to first ⊗
+    svg.push_str(r##"<line x1="75" y1="190" x2="145" y2="190" class="arrow"/>"##);
+    // f_t (σ output) to first ⊗
+    svg.push_str(r##"<line x1="160" y1="360" x2="160" y2="205" class="arrow"/>"##);
+
+    // Second ⊗: i_t × c̃_t (input × cell candidate)
+    svg.push_str(r##"<circle cx="280" cy="310" r="15" class="op-circle"/>"##);
+    svg.push_str(r##"<text x="280" y="310" class="label-bold">⊗</text>"##);
+    
+    // i_t to second ⊗
+    svg.push_str(r##"<path d="M 240 360 L 240 310 L 265 310" class="arrow"/>"##);
+    // c̃_t to second ⊗
+    svg.push_str(r##"<path d="M 320 360 L 320 310 L 295 310" class="arrow"/>"##);
+
+    // Third ⊗: o_t × tanh(c_t) (output gate operation)
+    svg.push_str(r##"<circle cx="480" cy="325" r="15" class="op-circle"/>"##);
+    svg.push_str(r##"<text x="480" y="325" class="label-bold">⊗</text>"##);
+    
+    // o_t to third ⊗
+    svg.push_str(r##"<path d="M 400 360 L 400 325 L 465 325" class="arrow"/>"##);
+    // tanh(c_t) to third ⊗
+    svg.push_str(r##"<line x1="462" y1="250" x2="480" y2="310" class="arrow"/>"##);
+
+    // ============ ADDITION OPERATION (⊕) ============
+    svg.push_str(r##"<circle cx="220" cy="190" r="15" class="op-circle"/>"##);
+    svg.push_str(r##"<text x="220" y="190" class="label-bold">⊕</text>"##);
+    
+    // From first ⊗ to ⊕
+    svg.push_str(r##"<line x1="175" y1="190" x2="205" y2="190" class="arrow"/>"##);
+    // From second ⊗ to ⊕
+    svg.push_str(r##"<path d="M 280 295 L 280 250 L 220 250 L 220 205" class="arrow"/>"##);
+
+    // ============ CONNECTIONS ============
+    // ⊕ output to c_t
+    svg.push_str(r##"<line x1="235" y1="190" x2="645" y2="190" class="arrow"/>"##);
+    
+    // Branch from c_t line to tanh(c_t)
+    svg.push_str(r##"<path d="M 380 190 L 380 250 L 438 250" class="arrow"/>"##);
+
+    // Third ⊗ output to VQC₅
+    svg.push_str(r##"<line x1="495" y1="325" x2="533" y2="325" class="arrow"/>"##);
+
+    // VQC₅ output to h_t
+    svg.push_str(r##"<line x1="588" y1="325" x2="645" y2="325" class="arrow"/>"##);
+
+    // h_t feedback to VQC₆ (goes up and left)
+    svg.push_str(r##"<path d="M 672 310 L 672 220 L 560 220 L 560 160" class="arrow"/>"##);
+
+    // VQC₆ to y_t
+    svg.push_str(r##"<line x1="560" y1="130" x2="560" y2="100" class="line"/>"##);
+    svg.push_str(r##"<line x1="560" y1="100" x2="645" y2="85" class="arrow"/>"##);
+
+    // ============ INPUT CONNECTIONS TO VQCs ============
+    // Combine x_t and h_{t-1} at bottom, then feed to all 4 VQCs
+    // Horizontal line at y=490 connecting all inputs
+    svg.push_str(r##"<path d="M 47 485 L 47 490 L 400 490" class="line"/>"##);
+    svg.push_str(r##"<path d="M 47 410 L 47 490" class="line"/>"##);
+    
+    // Vertical arrows up to each VQC
+    svg.push_str(r##"<line x1="160" y1="490" x2="160" y2="450" class="arrow"/>"##);
+    svg.push_str(r##"<line x1="240" y1="490" x2="240" y2="450" class="arrow"/>"##);
+    svg.push_str(r##"<line x1="320" y1="490" x2="320" y2="450" class="arrow"/>"##);
+    svg.push_str(r##"<line x1="400" y1="490" x2="400" y2="450" class="arrow"/>"##);
+
+    // ============ CLASSICAL POST-PROCESSING (Optional) ============
+    svg.push_str(r##"<rect x="430" y="40" width="90" height="40" rx="5" class="postproc-box"/>"##);
+    svg.push_str(r##"<text x="475" y="55" class="small-label">Classical</text>"##);
+    svg.push_str(r##"<text x="475" y="68" class="small-label">Post-processing</text>"##);
+    svg.push_str(r##"<text x="475" y="90" class="small-label" fill="#666">(Optional)</text>"##);
+    
+    // Arrow from post-processing to y_t
+    svg.push_str(r##"<line x1="520" y1="60" x2="645" y2="75" class="arrow"/>"##);
+
+    // ============ CONFIGURATION INFO ============
+    svg.push_str(&format!(
+        r##"<text x="375" y="555" class="small-label" fill="#666">Config: input={}, hidden={}, qubits={}, layers={}, type={}</text>"##,
+        config.input_size, config.hidden_size, config.num_qubits, config.num_layers, vqc_type_name
+    ));
+
+    svg.push_str("</svg>");
+    svg
+}
+
+/// Generate an SVG visualization of a single VQC
+pub fn vqc_svg_diagram(vqc: &VariationalQuantumCircuit) -> String {
+    let cell_width = 50;
+    let cell_height = 40;
+    let margin = 60;
+    let num_cols = vqc.num_layers * 3 + (if vqc.include_input_encoding { 2 } else { 1 });
+    let width = num_cols * cell_width + 2 * margin;
+    let height = vqc.num_qubits * cell_height + 2 * margin + 40;
+
+    let vqc_type_name = match vqc.vqc_type {
+        VQCType::Simple => "Simple",
+        VQCType::BasicEntangling => "BasicEntangling",
+        VQCType::StronglyEntangling => "StronglyEntangling",
+        VQCType::Custom => "Custom",
+    };
+
+    let mut svg = format!(
+        r##"<svg width="{}" height="{}" xmlns="http://www.w3.org/2000/svg">
+        <style>
+            .title {{ font-family: 'Courier New', monospace; font-size: 14px; font-weight: bold; text-anchor: middle; }}
+            .qubit-line {{ stroke: #000; stroke-width: 1; }}
+            .gate-box {{ fill: #E3F2FD; stroke: #1976D2; stroke-width: 1.5; rx: 3; }}
+            .entangle-box {{ fill: #E8F5E9; stroke: #4CAF50; stroke-width: 1.5; rx: 3; }}
+            .gate-text {{ font-family: 'Courier New', monospace; font-size: 10px; text-anchor: middle; dominant-baseline: middle; }}
+            .qubit-label {{ font-family: 'Courier New', monospace; font-size: 12px; text-anchor: end; dominant-baseline: middle; }}
+            .control-point {{ fill: #000; }}
+            .connector-line {{ stroke: #000; stroke-width: 1; }}
+        </style>
+        "##,
+        width, height
+    );
+
+    // Title
+    svg.push_str(&format!(
+        r##"<text x="{}" y="20" class="title">VQC: {} ({} qubits, {} layers)</text>"##,
+        width / 2, vqc_type_name, vqc.num_qubits, vqc.num_layers
+    ));
+
+    // Draw qubit lines
+    for q in 0..vqc.num_qubits {
+        let y = q * cell_height + margin;
+
+        // Qubit label
+        svg.push_str(&format!(
+            r##"<text x="{}" y="{}" class="qubit-label">q{}</text>"##,
+            margin - 10, y, q
+        ));
+
+        // Qubit line
+        svg.push_str(&format!(
+            r##"<line x1="{}" y1="{}" x2="{}" y2="{}" class="qubit-line"/>"##,
+            margin, y, width - margin, y
+        ));
+    }
+
+    let mut col = 0;
+
+    // Input encoding
+    if vqc.include_input_encoding {
+        for q in 0..vqc.num_qubits {
+            let x = col * cell_width + margin + cell_width / 2;
+            let y = q * cell_height + margin;
+
+            svg.push_str(&format!(
+                r##"<rect x="{}" y="{}" width="40" height="25" class="gate-box"/>"##,
+                x - 20, y - 12
+            ));
+            svg.push_str(&format!(
+                r##"<text x="{}" y="{}" class="gate-text">RY(x{})</text>"##,
+                x, y, q
+            ));
+        }
+        col += 1;
+    }
+
+    // Variational layers
+    for layer in 0..vqc.num_layers {
+        // Rotation gates
+        match vqc.vqc_type {
+            VQCType::Simple => {
+                let x = col * cell_width + margin + cell_width / 2;
+                for q in 0..vqc.num_qubits {
+                    let y = q * cell_height + margin;
+                    svg.push_str(&format!(
+                        r##"<rect x="{}" y="{}" width="30" height="20" class="gate-box"/>"##,
+                        x - 15, y - 10
+                    ));
+                    svg.push_str(&format!(
+                        r##"<text x="{}" y="{}" class="gate-text">RY</text>"##,
+                        x, y
+                    ));
+                }
+                col += 1;
+            }
+            VQCType::BasicEntangling | VQCType::Custom => {
+                // RY gates
+                let x = col * cell_width + margin + cell_width / 2;
+                for q in 0..vqc.num_qubits {
+                    let y = q * cell_height + margin;
+                    svg.push_str(&format!(
+                        r##"<rect x="{}" y="{}" width="30" height="20" class="gate-box"/>"##,
+                        x - 15, y - 10
+                    ));
+                    svg.push_str(&format!(
+                        r##"<text x="{}" y="{}" class="gate-text">RY</text>"##,
+                        x, y
+                    ));
+                }
+                col += 1;
+
+                // RZ gates
+                let x = col * cell_width + margin + cell_width / 2;
+                for q in 0..vqc.num_qubits {
+                    let y = q * cell_height + margin;
+                    svg.push_str(&format!(
+                        r##"<rect x="{}" y="{}" width="30" height="20" class="gate-box"/>"##,
+                        x - 15, y - 10
+                    ));
+                    svg.push_str(&format!(
+                        r##"<text x="{}" y="{}" class="gate-text">RZ</text>"##,
+                        x, y
+                    ));
+                }
+                col += 1;
+
+                // CNOT ladder
+                let x = col * cell_width + margin + cell_width / 2;
+                for q in 0..vqc.num_qubits.saturating_sub(1) {
+                    let control_y = q * cell_height + margin;
+                    let target_y = (q + 1) * cell_height + margin;
+
+                    svg.push_str(&format!(
+                        r##"<line x1="{}" y1="{}" x2="{}" y2="{}" class="connector-line"/>"##,
+                        x, control_y, x, target_y
+                    ));
+                    svg.push_str(&format!(
+                        r##"<circle cx="{}" cy="{}" r="4" class="control-point"/>"##,
+                        x, control_y
+                    ));
+                    svg.push_str(&format!(
+                        r##"<circle cx="{}" cy="{}" r="8" fill="none" stroke="#000" stroke-width="1.5"/>"##,
+                        x, target_y
+                    ));
+                    svg.push_str(&format!(
+                        r##"<line x1="{}" y1="{}" x2="{}" y2="{}" class="connector-line"/>"##,
+                        x - 8, target_y, x + 8, target_y
+                    ));
+                    svg.push_str(&format!(
+                        r##"<line x1="{}" y1="{}" x2="{}" y2="{}" class="connector-line"/>"##,
+                        x, target_y - 8, x, target_y + 8
+                    ));
+                }
+                col += 1;
+            }
+            VQCType::StronglyEntangling => {
+                // RZ-RY-RZ gates
+                for gate in ["RZ", "RY", "RZ"] {
+                    let x = col * cell_width + margin + cell_width / 2;
+                    for q in 0..vqc.num_qubits {
+                        let y = q * cell_height + margin;
+                        svg.push_str(&format!(
+                            r##"<rect x="{}" y="{}" width="30" height="20" class="gate-box"/>"##,
+                            x - 15, y - 10
+                        ));
+                        svg.push_str(&format!(
+                            r##"<text x="{}" y="{}" class="gate-text">{}</text>"##,
+                            x, y, gate
+                        ));
+                    }
+                    col += 1;
+                }
+
+                // CNOT chain with offset
+                let x = col * cell_width + margin + cell_width / 2;
+                let offset = layer % vqc.num_qubits;
+                for i in 0..vqc.num_qubits.saturating_sub(1) {
+                    let control = (i + offset) % vqc.num_qubits;
+                    let target = (i + 1 + offset) % vqc.num_qubits;
+                    if control != target {
+                        let control_y = control * cell_height + margin;
+                        let target_y = target * cell_height + margin;
+                        let (min_y, max_y) = if control_y < target_y {
+                            (control_y, target_y)
+                        } else {
+                            (target_y, control_y)
+                        };
+
+                        svg.push_str(&format!(
+                            r##"<line x1="{}" y1="{}" x2="{}" y2="{}" class="connector-line"/>"##,
+                            x, min_y, x, max_y
+                        ));
+                        svg.push_str(&format!(
+                            r##"<circle cx="{}" cy="{}" r="4" class="control-point"/>"##,
+                            x, control_y
+                        ));
+                        svg.push_str(&format!(
+                            r##"<circle cx="{}" cy="{}" r="8" fill="none" stroke="#000" stroke-width="1.5"/>"##,
+                            x, target_y
+                        ));
+                    }
+                }
+                col += 1;
+            }
+        }
+    }
+
+    // Measurement symbols
+    let x = col * cell_width + margin + cell_width / 2;
+    for q in 0..vqc.num_qubits {
+        let y = q * cell_height + margin;
+        svg.push_str(&format!(
+            r##"<rect x="{}" y="{}" width="30" height="20" fill="#FFF3E0" stroke="#FF9800" stroke-width="1.5" rx="3"/>"##,
+            x - 15, y - 10
+        ));
+        svg.push_str(&format!(
+            r##"<text x="{}" y="{}" class="gate-text">⟨Z⟩</text>"##,
+            x, y
+        ));
+    }
+
+    // Info text
+    svg.push_str(&format!(
+        r##"<text x="{}" y="{}" class="gate-text" style="font-size: 11px;">Parameters: {}</text>"##,
+        width / 2, height - 10, vqc.num_variational_params()
+    ));
+
+    svg.push_str("</svg>");
+    svg
+}
+
+/// Save QLSTM diagram to SVG file
+pub fn save_svg_diagram(config: &QLSTMConfig, filename: &str) -> Result<()> {
+    let svg = svg_diagram(config);
+    std::fs::write(filename, svg)
+}
+
+/// Save VQC diagram to SVG file
+pub fn save_vqc_svg_diagram(vqc: &VariationalQuantumCircuit, filename: &str) -> Result<()> {
+    let svg = vqc_svg_diagram(vqc);
+    std::fs::write(filename, svg)
+}
+
+/// View QLSTM diagram in browser
+pub fn view_qlstm(config: &QLSTMConfig) -> Result<()> {
+    let svg = svg_diagram(config);
+
+    let html = format!(
+        r##"<!DOCTYPE html>
+        <html>
+        <head>
+            <title>QLSTM Visualization</title>
+            <style>
+                body {{ font-family: sans-serif; margin: 20px; background: #f5f5f5; }}
+                .container {{ background: white; padding: 20px; border-radius: 10px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }}
+                h1 {{ color: #333; }}
+                pre {{ background: #f0f0f0; padding: 15px; border-radius: 5px; overflow-x: auto; }}
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <h1>QLSTM Cell Visualization</h1>
+                {}
+                <h2>Text Representation</h2>
+                <pre>{}</pre>
+            </div>
+        </body>
+        </html>"##,
+        svg,
+        text_diagram(config).replace('<', "&lt;").replace('>', "&gt;")
+    );
+
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("qlstm_visualization.html");
+    std::fs::write(&file_path, html)?;
+
+    if cfg!(target_os = "windows") {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", file_path.to_str().unwrap()])
+            .spawn()?;
+    } else if cfg!(target_os = "macos") {
+        std::process::Command::new("open").arg(file_path).spawn()?;
+    } else {
+        std::process::Command::new("xdg-open")
+            .arg(file_path)
+            .spawn()?;
+    }
+
+    Ok(())
+}
+
+// Implement Visualizable trait for QLSTM
+impl crate::vis::Visualizable for QLSTM {
+    fn visualize(&self) -> String {
+        text_diagram(self.config())
+    }
+
+    fn visualize_as_svg(&self) -> String {
+        svg_diagram(self.config())
+    }
+
+    fn save_visualization(&self, filename: &str) -> Result<()> {
+        save_svg_diagram(self.config(), filename)
+    }
+
+    fn view(&self) -> Result<()> {
+        view_qlstm(self.config())
+    }
+}
+
+// Implement Visualizable trait for VariationalQuantumCircuit
+impl crate::vis::Visualizable for VariationalQuantumCircuit {
+    fn visualize(&self) -> String {
+        vqc_text_diagram(self)
+    }
+
+    fn visualize_as_svg(&self) -> String {
+        vqc_svg_diagram(self)
+    }
+
+    fn save_visualization(&self, filename: &str) -> Result<()> {
+        save_vqc_svg_diagram(self, filename)
+    }
+
+    fn view(&self) -> Result<()> {
+        let svg = vqc_svg_diagram(self);
+        let html = format!(
+            r##"<!DOCTYPE html>
+            <html>
+            <head><title>VQC Visualization</title></head>
+            <body style="font-family: sans-serif; margin: 20px;">
+                <h1>Variational Quantum Circuit</h1>
+                {}
+            </body>
+            </html>"##,
+            svg
+        );
+
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join("vqc_visualization.html");
+        std::fs::write(&file_path, html)?;
+
+        if cfg!(target_os = "windows") {
+            std::process::Command::new("cmd")
+                .args(["/C", "start", file_path.to_str().unwrap()])
+                .spawn()?;
+        } else if cfg!(target_os = "macos") {
+            std::process::Command::new("open").arg(file_path).spawn()?;
+        } else {
+            std::process::Command::new("xdg-open")
+                .arg(file_path)
+                .spawn()?;
+        }
+
+        Ok(())
+    }
+}

--- a/tests/test_qml_qlstm.rs
+++ b/tests/test_qml_qlstm.rs
@@ -1,0 +1,426 @@
+//! QLSTM Integration Tests
+//!
+//! This module tests the QLSTM implementation with proper datasets:
+//! 1. Sine wave prediction (time series)
+//! 2. Simple addition task
+//! 3. XOR sequence task
+//! 4. Gradient verification
+//! 5. Variable sequence length handling
+
+use logosq::qml::{mse_loss, QLSTMConfig, VQCType, QLSTM};
+use rand::Rng;
+use std::f64::consts::PI;
+
+/// Generate sine wave dataset
+/// Returns (training_sequences, training_targets)
+fn generate_sine_dataset(
+    num_samples: usize,
+    seq_length: usize,
+) -> (Vec<Vec<Vec<f64>>>, Vec<Vec<f64>>) {
+    let mut rng = rand::thread_rng();
+    let mut sequences = Vec::new();
+    let mut targets = Vec::new();
+
+    for _ in 0..num_samples {
+        let phase: f64 = rng.gen_range(0.0..2.0 * PI);
+        let freq: f64 = rng.gen_range(0.5..2.0);
+
+        let mut seq = Vec::new();
+        for t in 0..seq_length {
+            let val = (freq * (t as f64) * 0.1 + phase).sin();
+            seq.push(vec![val]);
+        }
+
+        // Target is the next value in the sequence
+        let target_val = (freq * (seq_length as f64) * 0.1 + phase).sin();
+        // Scale target to match hidden size
+        let target = vec![target_val, target_val * 0.5];
+
+        sequences.push(seq);
+        targets.push(target);
+    }
+
+    (sequences, targets)
+}
+
+/// Simple addition task: predict sum of sequence
+fn generate_addition_dataset(
+    num_samples: usize,
+    seq_length: usize,
+) -> (Vec<Vec<Vec<f64>>>, Vec<Vec<f64>>) {
+    let mut rng = rand::thread_rng();
+    let mut sequences = Vec::new();
+    let mut targets = Vec::new();
+
+    for _ in 0..num_samples {
+        let mut seq = Vec::new();
+        let mut sum = 0.0;
+
+        for _ in 0..seq_length {
+            let val: f64 = rng.gen_range(-0.5..0.5);
+            seq.push(vec![val]);
+            sum += val;
+        }
+
+        // Normalize sum to be in reasonable range
+        let normalized_sum = (sum / seq_length as f64).tanh();
+        let target = vec![normalized_sum, normalized_sum * 0.5];
+
+        sequences.push(seq);
+        targets.push(target);
+    }
+
+    (sequences, targets)
+}
+
+/// XOR-like sequence task
+fn generate_xor_dataset(num_samples: usize) -> (Vec<Vec<Vec<f64>>>, Vec<Vec<f64>>) {
+    let mut rng = rand::thread_rng();
+    let mut sequences = Vec::new();
+    let mut targets = Vec::new();
+
+    for _ in 0..num_samples {
+        let a: f64 = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
+        let b: f64 = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
+
+        let seq = vec![vec![a * 0.5], vec![b * 0.5]];
+
+        // XOR: output 1 if inputs differ, -1 if same
+        let xor_result = if (a > 0.0) != (b > 0.0) { 0.5 } else { -0.5 };
+        let target = vec![xor_result, xor_result];
+
+        sequences.push(seq);
+        targets.push(target);
+    }
+
+    (sequences, targets)
+}
+
+/// Train QLSTM on dataset
+fn train_qlstm(
+    qlstm: &QLSTM,
+    train_sequences: &[Vec<Vec<f64>>],
+    train_targets: &[Vec<f64>],
+    initial_params: &[f64],
+    learning_rate: f64,
+    epochs: usize,
+) -> (Vec<f64>, Vec<f64>) {
+    let mut params = initial_params.to_vec();
+    let mut loss_history = Vec::new();
+
+    for _epoch in 0..epochs {
+        let mut epoch_loss = 0.0;
+
+        for (seq, target) in train_sequences.iter().zip(train_targets.iter()) {
+            // Forward pass
+            let output = qlstm.forward(seq, &params, None, None);
+            let loss = mse_loss(&output[0], target);
+            epoch_loss += loss;
+
+            // Compute gradient and update
+            let gradient = qlstm.compute_gradient(seq, target, &params, mse_loss);
+            for (p, g) in params.iter_mut().zip(gradient.iter()) {
+                *p -= learning_rate * g;
+            }
+        }
+
+        let avg_loss = epoch_loss / train_sequences.len() as f64;
+        loss_history.push(avg_loss);
+    }
+
+    (params, loss_history)
+}
+
+/// Evaluate QLSTM on test set
+fn evaluate_qlstm(
+    qlstm: &QLSTM,
+    test_sequences: &[Vec<Vec<f64>>],
+    test_targets: &[Vec<f64>],
+    params: &[f64],
+) -> f64 {
+    let mut total_loss = 0.0;
+
+    for (seq, target) in test_sequences.iter().zip(test_targets.iter()) {
+        let output = qlstm.forward(seq, params, None, None);
+        total_loss += mse_loss(&output[0], target);
+    }
+
+    total_loss / test_sequences.len() as f64
+}
+
+#[test]
+fn test_qlstm_sine_wave_prediction() {
+    // Smoke test for sine wave prediction with 6-VQC architecture
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(1)
+        .with_num_qubits(3)
+        .with_vqc_type(VQCType::Simple); // Use simpler VQC
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    // Generate dataset
+    let (train_seqs, train_targets) = generate_sine_dataset(10, 3);
+    let (test_seqs, test_targets) = generate_sine_dataset(3, 3);
+
+    // Initialize parameters with smaller range
+    let mut rng = rand::thread_rng();
+    let initial_params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.1..0.1)).collect();
+
+    // Evaluate before training
+    let initial_loss = evaluate_qlstm(&qlstm, &test_seqs, &test_targets, &initial_params);
+    assert!(initial_loss.is_finite(), "Initial loss should be finite");
+
+    // Train with fewer iterations (smoke test)
+    let (trained_params, loss_history) =
+        train_qlstm(&qlstm, &train_seqs, &train_targets, &initial_params, 0.02, 5);
+
+    // Verify training produces finite values
+    assert!(
+        loss_history.iter().all(|l| l.is_finite()),
+        "Training losses should be finite"
+    );
+
+    // Evaluate after training
+    let final_loss = evaluate_qlstm(&qlstm, &test_seqs, &test_targets, &trained_params);
+    assert!(final_loss.is_finite(), "Final loss should be finite");
+}
+
+#[test]
+fn test_qlstm_addition_task() {
+    // Smoke test for addition task with 6-VQC architecture
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(1)
+        .with_num_qubits(3)
+        .with_vqc_type(VQCType::Simple); // Use simpler VQC
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    // Generate dataset
+    let (train_seqs, train_targets) = generate_addition_dataset(15, 3);
+    let (test_seqs, test_targets) = generate_addition_dataset(5, 3);
+
+    // Initialize parameters with smaller range
+    let mut rng = rand::thread_rng();
+    let initial_params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.1..0.1)).collect();
+
+    let initial_loss = evaluate_qlstm(&qlstm, &test_seqs, &test_targets, &initial_params);
+    assert!(initial_loss.is_finite(), "Initial loss should be finite");
+
+    // Train with fewer iterations (smoke test)
+    let (trained_params, loss_history) =
+        train_qlstm(&qlstm, &train_seqs, &train_targets, &initial_params, 0.02, 5);
+
+    // Verify training produces finite values
+    assert!(
+        loss_history.iter().all(|l| l.is_finite()),
+        "Training losses should be finite"
+    );
+
+    let final_loss = evaluate_qlstm(&qlstm, &test_seqs, &test_targets, &trained_params);
+    assert!(final_loss.is_finite(), "Final loss should be finite");
+}
+
+#[test]
+fn test_qlstm_xor_sequence() {
+    // This test verifies that QLSTM can process XOR sequences correctly
+    // Note: With 6-VQC architecture, actual learning requires more iterations
+    // and careful hyperparameter tuning. This is a smoke test.
+    
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(1)
+        .with_num_qubits(3)
+        .with_vqc_type(VQCType::Simple); // Simplest VQC for smoke test
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    // Generate dataset
+    let (train_seqs, train_targets) = generate_xor_dataset(20);
+    let (test_seqs, test_targets) = generate_xor_dataset(5);
+
+    // Initialize parameters
+    let mut rng = rand::thread_rng();
+    let initial_params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.1..0.1)).collect();
+
+    // Verify forward pass works
+    let initial_loss = evaluate_qlstm(&qlstm, &test_seqs, &test_targets, &initial_params);
+    assert!(initial_loss.is_finite(), "Initial loss should be finite");
+
+    // Run a few training steps (smoke test)
+    let (trained_params, loss_history) =
+        train_qlstm(&qlstm, &train_seqs, &train_targets, &initial_params, 0.02, 5);
+
+    // Verify training doesn't produce NaN/Inf
+    assert!(
+        loss_history.iter().all(|l| l.is_finite()),
+        "Training losses should be finite"
+    );
+    
+    // Verify parameters were updated
+    let params_changed = initial_params
+        .iter()
+        .zip(trained_params.iter())
+        .any(|(a, b)| (a - b).abs() > 1e-10);
+    assert!(params_changed, "Parameters should change during training");
+
+    // Verify final evaluation works
+    let final_loss = evaluate_qlstm(&qlstm, &test_seqs, &test_targets, &trained_params);
+    assert!(final_loss.is_finite(), "Final loss should be finite");
+}
+
+#[test]
+fn test_qlstm_gradient_accuracy() {
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(1)
+        .with_num_qubits(3);
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    // Test data
+    let sequence = vec![vec![0.3], vec![0.5], vec![0.7]];
+    let target = vec![0.4, 0.6];
+
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.5..0.5)).collect();
+
+    // Compute analytical gradient (parameter-shift)
+    let analytical_grad = qlstm.compute_gradient(&sequence, &target, &params, mse_loss);
+
+    // Compute numerical gradient
+    let eps = 1e-4;
+    let mut numerical_grad = vec![0.0; num_params];
+    for i in 0..num_params {
+        let mut params_plus = params.clone();
+        params_plus[i] += eps;
+        let out_plus = qlstm.forward(&sequence, &params_plus, None, None);
+        let loss_plus = mse_loss(&out_plus[0], &target);
+
+        let mut params_minus = params.clone();
+        params_minus[i] -= eps;
+        let out_minus = qlstm.forward(&sequence, &params_minus, None, None);
+        let loss_minus = mse_loss(&out_minus[0], &target);
+
+        numerical_grad[i] = (loss_plus - loss_minus) / (2.0 * eps);
+    }
+
+    // Compare - gradients should be in same direction
+    let mut matching_signs = 0;
+    for i in 0..num_params {
+        if analytical_grad[i].abs() > 1e-6 && numerical_grad[i].abs() > 1e-6 {
+            if analytical_grad[i].signum() == numerical_grad[i].signum() {
+                matching_signs += 1;
+            }
+        } else {
+            // Both small, count as match
+            matching_signs += 1;
+        }
+    }
+
+    // At least 80% of gradients should have matching signs
+    let match_ratio = matching_signs as f64 / num_params as f64;
+    assert!(
+        match_ratio >= 0.8,
+        "Gradient signs should mostly match: {}%",
+        match_ratio * 100.0
+    );
+}
+
+#[test]
+fn test_qlstm_variable_sequence_length() {
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(1)
+        .with_num_qubits(3);
+
+    let qlstm = QLSTM::new(config);
+    let num_params = qlstm.num_parameters();
+
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.5..0.5)).collect();
+
+    // Test different sequence lengths
+    let lengths = vec![1, 3, 5, 10, 20];
+
+    for &len in &lengths {
+        let sequence: Vec<Vec<f64>> = (0..len).map(|i| vec![(i as f64) * 0.1]).collect();
+        let output = qlstm.forward(&sequence, &params, None, None);
+
+        // Should produce valid output for any sequence length
+        assert_eq!(output.len(), 1, "Should have one output");
+        assert_eq!(output[0].len(), 2, "Output should match hidden size");
+        
+        // Output values should be finite
+        for &val in &output[0] {
+            assert!(val.is_finite(), "Output should be finite for length {}", len);
+        }
+    }
+}
+
+#[test]
+fn test_qlstm_return_sequences() {
+    let config = QLSTMConfig::new(1, 2)
+        .with_num_layers(1)
+        .with_num_qubits(3);
+
+    let qlstm = QLSTM::new(config).with_return_sequences(true);
+    let num_params = qlstm.num_parameters();
+
+    let mut rng = rand::thread_rng();
+    let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.5..0.5)).collect();
+
+    let sequence = vec![vec![0.1], vec![0.2], vec![0.3], vec![0.4]];
+    let output = qlstm.forward(&sequence, &params, None, None);
+
+    // With return_sequences, should get output at each time step
+    assert_eq!(output.len(), 4, "Should return output for each time step");
+    
+    for (t, out) in output.iter().enumerate() {
+        assert_eq!(out.len(), 2, "Each output should match hidden size at t={}", t);
+    }
+}
+
+#[test]
+fn test_qlstm_different_vqc_types() {
+    let vqc_types = vec![
+        VQCType::Simple,
+        VQCType::BasicEntangling,
+        VQCType::StronglyEntangling,
+    ];
+
+    for vqc_type in vqc_types {
+        let config = QLSTMConfig::new(1, 2)
+            .with_num_layers(1)
+            .with_num_qubits(3)
+            .with_vqc_type(vqc_type.clone());
+
+        let qlstm = QLSTM::new(config);
+        let num_params = qlstm.num_parameters();
+
+        let mut rng = rand::thread_rng();
+        let params: Vec<f64> = (0..num_params).map(|_| rng.gen_range(-0.5..0.5)).collect();
+
+        let sequence = vec![vec![0.5], vec![0.3]];
+        let output = qlstm.forward(&sequence, &params, None, None);
+
+        // Should produce valid output for any VQC type
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].len(), 2);
+        
+        for &val in &output[0] {
+            assert!(val.is_finite(), "Output should be finite for {:?}", vqc_type);
+            assert!(val >= -1.0 && val <= 1.0, "Output should be in [-1, 1] range");
+        }
+    }
+}
+
+#[test]
+fn test_qlstm_mse_loss() {
+    let output = vec![0.5, 0.5];
+    let target = vec![1.0, 0.0];
+
+    let loss = mse_loss(&output, &target);
+    // MSE = ((0.5-1)^2 + (0.5-0)^2) / 2 = (0.25 + 0.25) / 2 = 0.25
+    assert!((loss - 0.25).abs() < 1e-6, "MSE loss calculation incorrect");
+}


### PR DESCRIPTION
## Summary

This PR implements Quantum Long Short-Term Memory (QLSTM) with a 6-VQC architecture as described in Figure 5 of the paper [arXiv:2009.01783](https://arxiv.org/abs/2009.01783).

## New Features

### QLSTM Module (`src/qml/`)
- **QLSTMCell** with 6 VQCs:
  - VQC₁-VQC₄: Forget, Input, Cell, Output gates
  - VQC₅: Hidden state processing (`h_t = VQC₅(o_t ⊙ tanh(c_t))`)
  - VQC₆: Output processing (`y_t = VQC₆(h_t)`)
- **QLSTM** layer for sequence processing
- **QLSTMTrainer** for basic gradient descent training
- **VQC types**: Simple, BasicEntangling, StronglyEntangling
- **Data encoding**: Angle, Amplitude, IQP encoding strategies

### Visualization (`src/vis/qlstm.rs`)
- SVG diagram generation for QLSTM cell architecture
- VQC circuit visualization with qubit lines, gates, and measurements
- Text-based diagram output

### Example (`examples/qlstm_demo.rs`)
- Comprehensive demo showcasing QLSTM functionality
- Generates SVG diagrams: `qlstm_cell.svg`, `qlstm_full.svg`, `qlstm_vqc.svg`

### Tests (`tests/test_qml_qlstm.rs`)
- Unit tests for QLSTM cell and layer
- Gradient accuracy tests using parameter-shift rule
- Smoke tests for training tasks (sine wave, addition, XOR)

## Architecture Diagram

```
                          ┌─────┐
    c_{t-1} ─────────────→│  ⊗  │────────────────────→ c_t
                          └──┬──┘
                             │
    [x_t, h_{t-1}] ──┬─→ VQC₁ → σ ─→ f_t ─┘
                     ├─→ VQC₂ → σ ─→ i_t ─┬→ ⊗ ─┬→ ⊕
                     ├─→ VQC₃ → tanh → c̃_t ┘    │
                     └─→ VQC₄ → σ ─→ o_t ─┬→ ⊗ ─┤
                                          │      │
                                    tanh(c_t) ←──┘
                                          │
                                          └─→ VQC₅ ──→ h_t ──→ VQC₆ ──→ y_t
```

## References
- [arXiv:2009.01783](https://arxiv.org/abs/2009.01783) - Quantum Long Short-Term Memory
- [PennyLane: Learning to Learn with Quantum Neural Networks](https://pennylane.ai/qml/demos/learning2learn)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Quantum ML stack centered on a 6‑VQC QLSTM, plus visualization, examples, and tests.
> 
> - Adds `src/qml/` with `qlstm` (6‑VQC cell, `QLSTM` layer, trainer, MSE/cross‑entropy losses), `vqc` (VQC types/builders/forward), and `data_encoding` (Angle/Amplitude/IQP)
> - New QLSTM/VQC visualization (`src/vis/qlstm.rs`): text and SVG diagrams; implements `Visualizable` and re-exports in `vis`
> - Example app `examples/qlstm_demo.rs` demonstrating forward pass, training, gradients, VQC types, and diagram generation
> - Comprehensive tests `tests/test_qml_qlstm.rs` for forward/stacked behavior, gradients, basic tasks, and losses
> - Public API: exports via `src/lib.rs` and `src/prelude.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit becb5b2f223e69cd2a122f62e3ba0feaac4e452a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->